### PR TITLE
Fix/intelli j tests issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,8 @@
         <spring-cloud.version>Hoxton.SR1</spring-cloud.version>
         <lombok.version>1.18.6</lombok.version>
         <testcontainers.version>1.10.6</testcontainers.version>
-        <junit5.version>5.6.0</junit5.version>
+        <junit5.version>5.5.2</junit5.version>
+        <junit-platform.version>1.5.2</junit-platform.version>
         <slf4j.version>1.7.16</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <reactor.version>3.3.3.RELEASE</reactor.version>
@@ -304,7 +305,6 @@
         <mockito-junit-jupiter.version>2.23.4</mockito-junit-jupiter.version>
         <jackson-databind.version>2.10.2</jackson-databind.version>
         <mockito-core.version>2.21.0</mockito-core.version>
-        <junit-platform.version>1.6.0</junit-platform.version>
         <spring-boot-admin-starter-client.version>2.1.3</spring-boot-admin-starter-client.version>
         <jackson-dataformat-yaml.version>2.10.2</jackson-dataformat-yaml.version>
         <playtika-embedded-containers.version>1.19</playtika-embedded-containers.version>


### PR DESCRIPTION
A solution without a fully-defined problem. Running the latest IntelliJ (2020.1) on linux/windows will result in a "tests not found" bug when running package tests. Individual test cases do run but even the encompassing test class is unable to run its own test cases.

Downgrading JUnit to version `5.5.2` resolves this issue but it is unclear as to where the conflict is, this is most likely a bug in IntelliJ but it could be something in this repo as well. JUnit platform version has also been downgraded to match.