### PR TITLE
Fix/113 analysis field issues

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -13,9 +13,9 @@ As an example, you can see in the `repositories` section of the following docume
       "access": "controlled",
       "study": "ABCD-CA",
       "analysis": {
-        "id": "EGAZ",
-        "type": "sequencingRead",
-        "state": "PUBLISHED",
+        "analysis_id": "EGAZ",
+        "analysis_type": "sequencingRead",
+        "analysis_state": "PUBLISHED",
         "study": "ABCD-CA",
         "experiment": {
           "analysisId": "EGAZ",

--- a/maestro-app/src/main/resources/config/application.yml
+++ b/maestro-app/src/main/resources/config/application.yml
@@ -6,6 +6,7 @@ maestro:
     # -1 = unlimited memory size
     maxInMemorySize: -1
   song:
+    indexableStudyStatus: PUBLISHED
     maxRetries: 3
     timeoutSec:
         study: 100 # some studies take really long, +30 secs, to be downloaded

--- a/maestro-app/src/main/resources/file_centric.json
+++ b/maestro-app/src/main/resources/file_centric.json
@@ -3,8 +3,8 @@
     "file_centric": {}
   },
   "settings": {
-    "index.number_of_shards" : 11,
-    "index.max_result_window":300000,
+    "index.number_of_shards": 11,
+    "index.max_result_window": 300000,
     "analysis": {
       "analyzer": {
         "autocomplete_analyzed": {
@@ -83,13 +83,16 @@
       "file_access": {
         "type": "keyword"
       },
-      "analysis" : {
-        "properties" : {
-          "analysis_id" : {
+      "analysis": {
+        "properties": {
+          "analysis_id": {
             "type": "keyword",
             "copy_to": [
               "file_autocomplete"
             ]
+          },
+          "analysis_state": {
+            "type": "keyword"
           },
           "analysis_type": {
             "type": "keyword"

--- a/maestro-app/src/test/resources/config/application.yml
+++ b/maestro-app/src/test/resources/config/application.yml
@@ -9,6 +9,7 @@ maestro:
       donor:
         - DO52693
   song:
+    indexableStudyStatus: PUBLISHED
     maxRetries: 3
     timeoutSec:
       study: 5

--- a/maestro-app/src/test/resources/fixtures/FileCentricElasticSearchAdapterUnavaibilityTest/PEME-CA.files.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricElasticSearchAdapterUnavaibilityTest/PEME-CA.files.json
@@ -10,7 +10,6 @@
       "analysis_type": "sequencingRead",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PEME-CA",
       "experiment": {
         "analysisId": "EGAZ00001254368",
         "aligned": true,

--- a/maestro-app/src/test/resources/fixtures/FileCentricElasticSearchAdapterUnavaibilityTest/PEME-CA.files.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricElasticSearchAdapterUnavaibilityTest/PEME-CA.files.json
@@ -9,7 +9,7 @@
       "analysis_id": "EGAZ00001254368",
       "analysis_type": "sequencingRead",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "EGAZ00001254368",
         "aligned": true,

--- a/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc0.json
+++ b/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc0.json
@@ -6,9 +6,9 @@
   "study_id": "PEME-CA",
   "analysis": {
     "analysis_id": "EGAZ00001254368",
+    "analysis_state": "PUBLISHED",
     "analysis_type": "sequencingRead",
     "analysis_version": "1",
-    "state": "PUBLISHED",
     "info": {
       "dcc_project_code": "PEME-CA",
       "isPcawg": false
@@ -49,7 +49,7 @@
   "donors": [
     {
       "id": "DO232978",
-      "gender" : "Female",
+      "gender": "Female",
       "submitter_donor_id": "MDT-AP-0749",
       "specimens": {
         "id": "SP201301",

--- a/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc0.json
+++ b/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc0.json
@@ -9,7 +9,6 @@
     "analysis_type": "sequencingRead",
     "analysis_version": "1",
     "state": "PUBLISHED",
-    "study_id": "PEME-CA",
     "info": {
       "dcc_project_code": "PEME-CA",
       "isPcawg": false

--- a/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc1.json
+++ b/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc1.json
@@ -13,7 +13,6 @@
       "dcc_project_code": "PEME-CA",
       "isPcawg": false
     },
-    "study_id": "PEME-CA",
     "experiment": {
       "analysisId": "EGAZ00001254247",
       "aligned": true,

--- a/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc1.json
+++ b/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc1.json
@@ -8,7 +8,7 @@
     "analysis_id": "EGAZ00001254247",
     "analysis_type": "sequencingRead",
     "analysis_version": "1",
-    "state": "PUBLISHED",
+    "analysis_state": "PUBLISHED",
     "info": {
       "dcc_project_code": "PEME-CA",
       "isPcawg": false

--- a/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc2.json
+++ b/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc2.json
@@ -13,7 +13,6 @@
       "dcc_project_code": "PEME-CA",
       "isPcawg": false
     },
-    "study_id": "PEME-CA",
     "experiment": {
       "info": {},
       "analysisId": "EGAZ00001254247",

--- a/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc2.json
+++ b/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/doc2.json
@@ -8,7 +8,7 @@
     "analysis_id": "EGAZ00001254247",
     "analysis_type": "sequencingRead",
     "analysis_version": "1",
-    "state": "PUBLISHED",
+    "analysis_state": "PUBLISHED",
     "info": {
       "dcc_project_code": "PEME-CA",
       "isPcawg": false

--- a/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/docs.json
+++ b/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/docs.json
@@ -10,7 +10,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "info": {},
@@ -74,7 +73,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "info": {},
@@ -138,7 +136,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "info": {},
@@ -202,7 +199,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "info": {},
@@ -266,7 +262,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "info": {},
@@ -330,7 +325,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "info": {},
@@ -394,7 +388,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "info": {},
@@ -458,7 +451,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
@@ -522,7 +514,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
@@ -586,7 +577,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
@@ -650,7 +640,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
@@ -714,7 +703,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "info": {},
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
@@ -779,7 +767,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -843,7 +830,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "info": {},
@@ -907,7 +893,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -971,7 +956,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -1035,7 +1019,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "info": {},
@@ -1099,7 +1082,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -1162,7 +1144,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "info": {},
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -1226,7 +1207,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "info": {},
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -1291,7 +1271,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -1355,7 +1334,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "info": {},
@@ -1419,7 +1397,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -1483,7 +1460,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "info": {},
@@ -1547,7 +1523,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "info": {},
@@ -1611,7 +1586,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "info": {},
@@ -1675,7 +1649,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "info": {},
@@ -1739,7 +1712,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -1803,7 +1775,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -1867,7 +1838,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "b8e09611-225a-4de6-87dc-104753072252",
         "info": {},
@@ -1931,7 +1901,6 @@
       "analysis_version": "1",
       "state": "PUBLISHED",
       "info": {},
-      "study_id": "MALY-DE",
       "experiment": {
         "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
         "variantCallingTool": "MUSE variant call pipeline",
@@ -1994,7 +1963,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "MALY-DE",
       "info": {},
       "experiment": {
         "analysisId": "327c74cd-ee0b-4885-bafd-741e17b8b163",

--- a/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/docs.json
+++ b/maestro-app/src/test/resources/fixtures/IndexerIntegrationTest/docs.json
@@ -9,7 +9,7 @@
       "analysis_id": "909614f0-ceeb-11e5-8498-af7e4d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "info": {},
@@ -72,7 +72,7 @@
       "analysis_id": "909614f0-ceeb-11e5-8498-af7e4d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "info": {},
@@ -135,7 +135,7 @@
       "analysis_id": "909614f0-ceeb-11e5-8498-af7e4d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "info": {},
@@ -198,7 +198,7 @@
       "analysis_id": "909614f0-ceeb-11e5-8498-af7e4d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "info": {},
@@ -261,7 +261,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "info": {},
@@ -324,7 +324,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "info": {},
@@ -387,7 +387,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "info": {},
@@ -450,7 +450,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
@@ -513,7 +513,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
@@ -576,7 +576,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
@@ -639,7 +639,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
@@ -702,7 +702,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
@@ -765,7 +765,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
@@ -828,7 +828,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
@@ -891,7 +891,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
@@ -954,7 +954,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
@@ -1017,7 +1017,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
@@ -1080,7 +1080,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
@@ -1143,7 +1143,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -1206,7 +1206,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -1269,7 +1269,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -1332,7 +1332,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -1395,7 +1395,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -1458,7 +1458,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -1521,7 +1521,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -1584,7 +1584,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
@@ -1647,7 +1647,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
@@ -1710,7 +1710,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
@@ -1773,7 +1773,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
@@ -1836,7 +1836,7 @@
       "analysis_id": "b8e09611-225a-4de6-87dc-104753072252",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "b8e09611-225a-4de6-87dc-104753072252",
@@ -1899,7 +1899,7 @@
       "analysis_id": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
@@ -1962,7 +1962,7 @@
       "analysis_id": "327c74cd-ee0b-4885-bafd-741e17b8b163",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "info": {},
       "experiment": {
         "analysisId": "327c74cd-ee0b-4885-bafd-741e17b8b163",

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/api/FileCentricDocumentConverter.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/api/FileCentricDocumentConverter.java
@@ -82,7 +82,6 @@ final class FileCentricDocumentConverter {
                 .state(analysis.getAnalysisState())
                 .analysisType(analysis.getAnalysisType().getName())
                 .analysisVersion(analysis.getAnalysisType().getVersion())
-                .studyId(analysis.getStudyId())
                 .experiment(analysis.getExperiment())
                 .build()
             )

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/api/FileCentricDocumentConverter.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/api/FileCentricDocumentConverter.java
@@ -79,7 +79,7 @@ final class FileCentricDocumentConverter {
             .fileAccess(file.getFileAccess())
             .analysis(FileCentricAnalysis.builder()
                 .analysisId(analysis.getAnalysisId())
-                .state(analysis.getAnalysisState())
+                .analysisState(analysis.getAnalysisState())
                 .analysisType(analysis.getAnalysisType().getName())
                 .analysisVersion(analysis.getAnalysisType().getVersion())
                 .experiment(analysis.getExperiment())

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/FileCentricAnalysis.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/FileCentricAnalysis.java
@@ -44,7 +44,6 @@ public class FileCentricAnalysis {
     private String state;
     @NonNull
     private Map<String, Object> experiment;
-    private String studyId;
     /**
      * this field is to capture the dynamic fields in the analysis.
      * it's the responsibility of the users to make sure the mapping is consistent with

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/FileCentricAnalysis.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/FileCentricAnalysis.java
@@ -41,7 +41,7 @@ public class FileCentricAnalysis {
     @NonNull
     private Integer analysisVersion;
     @NonNull
-    private String state;
+    private String analysisState;
     @NonNull
     private Map<String, Object> experiment;
     /**

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/LIRI-JP.files.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/LIRI-JP.files.json
@@ -9,7 +9,7 @@
       "analysis_id": "909614f0-ceeb-11e5-8498-af7e4d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -71,7 +71,7 @@
       "analysis_id": "909614f0-ceeb-11e5-8498-af7e4d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -133,7 +133,7 @@
       "analysis_id": "909614f0-ceeb-11e5-8498-af7e4d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -195,7 +195,7 @@
       "analysis_id": "909614f0-ceeb-11e5-8498-af7e4d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -257,7 +257,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -319,7 +319,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -381,7 +381,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -443,7 +443,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -505,7 +505,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -567,7 +567,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -629,7 +629,7 @@
       "analysis_id": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -691,7 +691,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -753,7 +753,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -815,7 +815,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -877,7 +877,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -939,7 +939,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -1001,7 +1001,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -1063,7 +1063,7 @@
       "analysis_id": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/LIRI-JP.files.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/LIRI-JP.files.json
@@ -10,7 +10,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -73,7 +72,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -136,7 +134,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -199,7 +196,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -262,7 +258,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -325,7 +320,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -388,7 +382,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -451,7 +444,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -514,7 +506,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -577,7 +568,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -640,7 +630,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
         "variantCallingTool": "Broad variant call pipeline",
@@ -703,7 +692,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -766,7 +754,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -829,7 +816,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -892,7 +878,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -955,7 +940,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -1018,7 +1002,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",
@@ -1081,7 +1064,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "LIRI-JP",
       "experiment": {
         "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
         "variantCallingTool": "Broad variant call pipeline",

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/MALY-DE.files.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/MALY-DE.files.json
@@ -10,7 +10,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "MALY-DE",
       "experiment": {
         "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
         "variantCallingTool": "MUSE variant call pipeline",
@@ -73,7 +72,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "MALY-DE",
       "experiment": {
         "analysisId": "64e6f498-20ae-4c59-a5f5-36b18f81bd99",
         "variantCallingTool": " PCAWG SNV-MNV callers",
@@ -136,7 +134,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "MALY-DE",
       "experiment": {
         "analysisId": "327c74cd-ee0b-4885-bafd-741e17b8b163",
         "variantCallingTool": "PCAWG InDel callers",

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/MALY-DE.files.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/MALY-DE.files.json
@@ -9,7 +9,7 @@
       "analysis_id": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
         "variantCallingTool": "MUSE variant call pipeline",
@@ -71,7 +71,7 @@
       "analysis_id": "64e6f498-20ae-4c59-a5f5-36b18f81bd99",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "64e6f498-20ae-4c59-a5f5-36b18f81bd99",
         "variantCallingTool": " PCAWG SNV-MNV callers",
@@ -133,7 +133,7 @@
       "analysis_id": "327c74cd-ee0b-4885-bafd-741e17b8b163",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "327c74cd-ee0b-4885-bafd-741e17b8b163",
         "variantCallingTool": "PCAWG InDel callers",

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PACA-CA.files.excluded.SA520221.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PACA-CA.files.excluded.SA520221.json
@@ -9,7 +9,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -71,7 +71,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -133,7 +133,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -195,7 +195,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -257,7 +257,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -319,7 +319,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -381,7 +381,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -443,7 +443,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -505,7 +505,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -567,7 +567,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -629,7 +629,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PACA-CA.files.excluded.SA520221.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PACA-CA.files.excluded.SA520221.json
@@ -9,7 +9,6 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -73,7 +72,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -135,7 +133,6 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -198,7 +195,6 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -261,7 +257,6 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -324,7 +319,6 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -387,7 +381,6 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
@@ -450,7 +443,6 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
@@ -513,7 +505,6 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
@@ -576,7 +567,6 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
@@ -639,9 +629,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "study_id": "PACA-CA",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PACA-CA.files.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PACA-CA.files.json
@@ -10,7 +10,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -73,7 +72,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -136,7 +134,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -199,7 +196,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -262,7 +258,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -325,7 +320,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -388,7 +382,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -451,7 +444,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -514,7 +506,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -577,7 +568,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -640,7 +630,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -703,7 +692,6 @@
       "analysis_type": "variantCall",
       "analysis_version": "1",
       "state": "PUBLISHED",
-      "study_id": "PACA-CA",
       "experiment": {
         "analysisId": "b8e09611-225a-4de6-87dc-104753072252",
         "variantCallingTool": "PCAWG InDel callers",

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PACA-CA.files.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PACA-CA.files.json
@@ -9,7 +9,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -71,7 +71,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -133,7 +133,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -195,7 +195,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -257,7 +257,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -319,7 +319,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -381,7 +381,7 @@
       "analysis_id": "744c62bf-4747-4ab2-aca9-50879cea82e0",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
         "variantCallingTool": "DKFZ/EMBL variant call pipeline",
@@ -443,7 +443,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -505,7 +505,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -567,7 +567,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -629,7 +629,7 @@
       "analysis_id": "916b5a92-cea6-11e5-af30-d4714d100685",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
         "variantCallingTool": "Sanger variant call pipeline",
@@ -691,7 +691,7 @@
       "analysis_id": "b8e09611-225a-4de6-87dc-104753072252",
       "analysis_type": "variantCall",
       "analysis_version": "1",
-      "state": "PUBLISHED",
+      "analysis_state": "PUBLISHED",
       "experiment": {
         "analysisId": "b8e09611-225a-4de6-87dc-104753072252",
         "variantCallingTool": "PCAWG InDel callers",

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PEME-CA.files.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PEME-CA.files.json
@@ -9,7 +9,7 @@
       "analysis_id": "EGAZ00001254368",
       "analysis_type" : "sequencingRead",
       "analysis_version" : 1,
-      "state" : "PUBLISHED",
+      "analysis_state" : "PUBLISHED",
       "experiment": {
         "analysisId": "EGAZ00001254368",
         "aligned": true,

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PEME-CA.files.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/PEME-CA.files.json
@@ -10,7 +10,6 @@
       "analysis_type" : "sequencingRead",
       "analysis_version" : 1,
       "state" : "PUBLISHED",
-      "study_id": "PEME-CA",
       "experiment": {
         "analysisId": "EGAZ00001254368",
         "aligned": true,


### PR DESCRIPTION
- `state` renamed to `analysis_state` and included in index
- `study_id` field removed
- `SongAnalysisStreamListener` now respects configured acceptable analysis state to process
- Test case added for `SongAnalysisStreamListener` to test processing both `PUBLISHED` and `SUPPRESSED` states
- `features.md` analysis section updated for latest changes