### PR TITLE
Modified conflict resolution to enable upserts.

### DIFF
--- a/maestro-app/src/main/java/bio/overture/maestro/app/infra/adapter/inbound/messaging/song/AnalysisMessage.java
+++ b/maestro-app/src/main/java/bio/overture/maestro/app/infra/adapter/inbound/messaging/song/AnalysisMessage.java
@@ -17,6 +17,7 @@
 
 package bio.overture.maestro.app.infra.adapter.inbound.messaging.song;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
@@ -25,6 +26,7 @@ import lombok.Value;
 @Value
 @ToString
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 class AnalysisMessage {
   @NonNull private final String analysisId;
   @NonNull private final String studyId;

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/FileCentricDocument.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/FileCentricDocument.java
@@ -102,7 +102,9 @@ public class FileCentricDocument {
         && this.fileType.equals(fileCentricDocument.getFileType())
         && this.fileAccess.equals(fileCentricDocument.getFileAccess())
         && this.donors.equals(fileCentricDocument.getDonors())
-        && this.analysis.equals(fileCentricDocument.getAnalysis())
+        // FIXME: Might need a rethink of the replica problem as we need to be able to upsert more fields
+        && this.analysis.getAnalysisId().equals(fileCentricDocument.getAnalysis().getAnalysisId())
+        && this.analysis.getAnalysisType().equals(fileCentricDocument.getAnalysis().getAnalysisType())
         && this.file.equals(fileCentricDocument.getFile());
   }
 }

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/FileCentricDocument.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/FileCentricDocument.java
@@ -102,9 +102,12 @@ public class FileCentricDocument {
         && this.fileType.equals(fileCentricDocument.getFileType())
         && this.fileAccess.equals(fileCentricDocument.getFileAccess())
         && this.donors.equals(fileCentricDocument.getDonors())
-        // FIXME: Might need a rethink of the replica problem as we need to be able to upsert more fields
+        // FIXME: Might need a rethink of the replica problem as we need to be able to upsert more
+        // fields
         && this.analysis.getAnalysisId().equals(fileCentricDocument.getAnalysis().getAnalysisId())
-        && this.analysis.getAnalysisType().equals(fileCentricDocument.getAnalysis().getAnalysisType())
+        && this.analysis
+            .getAnalysisType()
+            .equals(fileCentricDocument.getAnalysis().getAnalysisType())
         && this.file.equals(fileCentricDocument.getFile());
   }
 }

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/analysis/AnalysisCentricDocument.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/analysis/AnalysisCentricDocument.java
@@ -66,7 +66,8 @@ public class AnalysisCentricDocument {
     if (this.equals(analysisCentricDocument)) return true;
     return this.analysisId.equals(analysisCentricDocument.getAnalysisId())
         && this.analysisType.equals(analysisCentricDocument.getAnalysisType())
-        // FIXME: Might need a rethink of the replica problem as we need to be able to upsert more fields
+        // FIXME: Might need a rethink of the replica problem as we need to be able to upsert more
+        // fields
         // && this.analysisState.equals(analysisCentricDocument.getAnalysisState())
         // && this.analysisVersion.equals(analysisCentricDocument.getAnalysisVersion())
         && this.studyId.equals(analysisCentricDocument.getStudyId())

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/analysis/AnalysisCentricDocument.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/analysis/AnalysisCentricDocument.java
@@ -66,8 +66,9 @@ public class AnalysisCentricDocument {
     if (this.equals(analysisCentricDocument)) return true;
     return this.analysisId.equals(analysisCentricDocument.getAnalysisId())
         && this.analysisType.equals(analysisCentricDocument.getAnalysisType())
-        && this.analysisState.equals(analysisCentricDocument.getAnalysisState())
-        && this.analysisVersion.equals(analysisCentricDocument.getAnalysisVersion())
+        // FIXME: Might need a rethink of the replica problem as we need to be able to upsert more fields
+        // && this.analysisState.equals(analysisCentricDocument.getAnalysisState())
+        // && this.analysisVersion.equals(analysisCentricDocument.getAnalysisVersion())
         && this.studyId.equals(analysisCentricDocument.getStudyId())
         && this.donors.equals(analysisCentricDocument.getDonors())
         && this.files.equals(analysisCentricDocument.getFiles());

--- a/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/MALY-DE.conflicting.analysis.json
+++ b/maestro-domain/src/test/resources/fixtures/DefaultIndexerTest/MALY-DE.conflicting.analysis.json
@@ -1,7 +1,7 @@
 [
   {
     "analysisType": {
-      "name": "variantCall",
+      "name": "sequencingRead",
       "version": 1
     },
     "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",


### PR DESCRIPTION
I recognize the type of upserts we need to do is starting to move beyond what maestro originally was designed to handle when it comes to file replication across multiple repositories. 

It looks more and more that maestro for handling file replication will be used a conversion tool rather than all the way to indexing for the platform, and for rdpc functionality it looks like it will need more and more upsert features as it evolves.

I've left FIXME comments to mark where we need to start thinking about the idea of "conflicts".