### PR TITLE
should index first_published_at for analysis and file centric

### DIFF
--- a/maestro-app/src/main/java/bio/overture/maestro/app/infra/adapter/outbound/indexing/elasticsearch/AnalysisCentricElasticSearchAdapter.java
+++ b/maestro-app/src/main/java/bio/overture/maestro/app/infra/adapter/outbound/indexing/elasticsearch/AnalysisCentricElasticSearchAdapter.java
@@ -146,15 +146,22 @@ public class AnalysisCentricElasticSearchAdapter implements AnalysisCentricIndex
   private UpdateRequest mapAnalysisToUpsertRepositoryQuery(
       AnalysisCentricDocument analysisCentricDocument) {
     val mapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+
     val paramsBuilder = new HashMap<String, Object>();
     paramsBuilder.put(
         "repository",
         mapper.convertValue(analysisCentricDocument.getRepositories().get(0), Map.class));
     paramsBuilder.put("analysis_state", analysisCentricDocument.getAnalysisState());
     paramsBuilder.put("updated_at", getDateIso(analysisCentricDocument.getUpdatedAt()));
-    if (analysisCentricDocument.getPublishedAt()
-        != null) { // Nullable as may not have been published
+
+    if (analysisCentricDocument.getPublishedAt() != null) {
+      // Nullable as may not have been published
       paramsBuilder.put("published_at", getDateIso(analysisCentricDocument.getPublishedAt()));
+    }
+
+    if (analysisCentricDocument.getFirstPublishedAt() != null) {
+      paramsBuilder.put(
+          "first_published_at", getDateIso(analysisCentricDocument.getFirstPublishedAt()));
     }
 
     val parameters = unmodifiableMap(paramsBuilder);

--- a/maestro-app/src/main/java/bio/overture/maestro/app/infra/adapter/outbound/indexing/elasticsearch/FileCentricElasticSearchAdapter.java
+++ b/maestro-app/src/main/java/bio/overture/maestro/app/infra/adapter/outbound/indexing/elasticsearch/FileCentricElasticSearchAdapter.java
@@ -277,10 +277,17 @@ class FileCentricElasticSearchAdapter implements FileCentricIndexAdapter {
         "repository", mapper.convertValue(fileCentricDocument.getRepositories().get(0), Map.class));
     paramsBuilder.put("analysis_state", fileCentricDocument.getAnalysis().getAnalysisState());
     paramsBuilder.put("updated_at", getDateIso(fileCentricDocument.getAnalysis().getUpdatedAt()));
-    if (fileCentricDocument.getAnalysis().getPublishedAt()
-        != null) { // Nullable as may not have been published
+
+    if (fileCentricDocument.getAnalysis().getPublishedAt() != null) {
+      // Nullable as may not have been published
       paramsBuilder.put(
           "published_at", getDateIso(fileCentricDocument.getAnalysis().getPublishedAt()));
+    }
+
+    if (fileCentricDocument.getAnalysis().getFirstPublishedAt() != null) {
+      paramsBuilder.put(
+          "first_published_at",
+          getDateIso(fileCentricDocument.getAnalysis().getFirstPublishedAt()));
     }
 
     val parameters = unmodifiableMap(paramsBuilder);

--- a/maestro-app/src/main/java/bio/overture/maestro/app/infra/adapter/outbound/indexing/elasticsearch/SearchAdapterHelper.java
+++ b/maestro-app/src/main/java/bio/overture/maestro/app/infra/adapter/outbound/indexing/elasticsearch/SearchAdapterHelper.java
@@ -211,7 +211,8 @@ public class SearchAdapterHelper {
             "if (!ctx._source.repositories.contains(params.repository)) { ctx._source.repositories.add(params.repository) } \n"
                 + "ctx._source.analysis_state = params.analysis_state;\n"
                 + "ctx._source.updated_at = ZonedDateTime.parse(params.updated_at).toInstant().toEpochMilli();\n"
-                + "if (params.published_at != null) { ctx._source.published_at = ZonedDateTime.parse(params.published_at).toInstant().toEpochMilli(); }\n",
+                + "if (params.published_at != null) { ctx._source.published_at = ZonedDateTime.parse(params.published_at).toInstant().toEpochMilli(); }\n"
+                + "if (params.first_published_at != null) { ctx._source.first_published_at = ZonedDateTime.parse(params.first_published_at).toInstant().toEpochMilli(); }\n",
             parameters);
     return inline;
   }
@@ -224,7 +225,8 @@ public class SearchAdapterHelper {
             "if (!ctx._source.repositories.contains(params.repository)) { ctx._source.repositories.add(params.repository) }\n"
                 + "ctx._source.analysis.analysis_state = params.analysis_state;\n"
                 + "ctx._source.analysis.updated_at = ZonedDateTime.parse(params.updated_at).toInstant().toEpochMilli();\n"
-                + "if (params.published_at != null) { ctx._source.analysis.published_at = ZonedDateTime.parse(params.published_at).toInstant().toEpochMilli(); }\n",
+                + "if (params.published_at != null) { ctx._source.analysis.published_at = ZonedDateTime.parse(params.published_at).toInstant().toEpochMilli(); }\n"
+                + "if (params.first_published_at != null) { ctx._source.analysis.first_published_at = ZonedDateTime.parse(params.first_published_at).toInstant().toEpochMilli(); }\n",
             parameters);
     return inline;
   }


### PR DESCRIPTION
Fix for maestro failing to update `first_published_at` if the previous value is null. 