### PR TITLE
when comparing list of files, should ignore order

### DIFF
--- a/maestro-domain/pom.xml
+++ b/maestro-domain/pom.xml
@@ -45,6 +45,11 @@
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/analysis/AnalysisCentricDocument.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/indexing/analysis/AnalysisCentricDocument.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import lombok.*;
 import lombok.experimental.FieldNameConstants;
+import org.apache.commons.collections4.CollectionUtils;
 
 @Builder
 @Getter
@@ -71,7 +72,7 @@ public class AnalysisCentricDocument {
         // && this.analysisState.equals(analysisCentricDocument.getAnalysisState())
         // && this.analysisVersion.equals(analysisCentricDocument.getAnalysisVersion())
         && this.studyId.equals(analysisCentricDocument.getStudyId())
-        && this.donors.equals(analysisCentricDocument.getDonors())
-        && this.files.equals(analysisCentricDocument.getFiles());
+        && CollectionUtils.isEqualCollection(this.donors, analysisCentricDocument.getDonors())
+        && CollectionUtils.isEqualCollection(this.files, analysisCentricDocument.getFiles());
   }
 }


### PR DESCRIPTION
Bug fix for TCRB-CA analysis id 53590f72-e0bd-4554-990f-72e0bdc554b5 failed to index when maestro compares the existing `List files` with new list of files using `List.equals()`. This method returns true only when the order of elements in the lists is the same, this results in maestro returning a conflict and refuses to update. 

The fix is to use `CollectionUtils.isEqualCollection` which ignores orders of elements, and returns true when the lists have exactly the same elements with exactly the same cardinalities. 