### PR TITLE
use song performance upgraded paginated get analysis endpoint

### DIFF
--- a/maestro-app/src/main/java/bio/overture/maestro/app/infra/config/properties/ApplicationProperties.java
+++ b/maestro-app/src/main/java/bio/overture/maestro/app/infra/config/properties/ApplicationProperties.java
@@ -80,6 +80,8 @@ public interface ApplicationProperties {
 
   String indexableStudyStatuses();
 
+  int pageLimit();
+
   int songAnalysisCallTimeoutSeconds();
 
   Slack.SlackChannelInfo getSlackChannelInfo();

--- a/maestro-app/src/main/java/bio/overture/maestro/app/infra/config/properties/DefaultApplicationProperties.java
+++ b/maestro-app/src/main/java/bio/overture/maestro/app/infra/config/properties/DefaultApplicationProperties.java
@@ -275,7 +275,7 @@ final class DefaultApplicationProperties implements ApplicationProperties {
     private int maxRetries = 3;
     // FIXME: This configuration is called three different things in this codebase
     private String indexableStudyStatesCsv = "PUBLISHED";
-    private int pageLimit = 100;
+    private int pageLimit = 25;
   }
 
   @Data

--- a/maestro-app/src/main/java/bio/overture/maestro/app/infra/config/properties/DefaultApplicationProperties.java
+++ b/maestro-app/src/main/java/bio/overture/maestro/app/infra/config/properties/DefaultApplicationProperties.java
@@ -172,6 +172,11 @@ final class DefaultApplicationProperties implements ApplicationProperties {
   }
 
   @Override
+  public int pageLimit() {
+    return this.song.getPageLimit();
+  }
+
+  @Override
   public int songAnalysisCallTimeoutSeconds() {
     return this.song.getTimeoutSec().getAnalysis();
   }
@@ -270,6 +275,7 @@ final class DefaultApplicationProperties implements ApplicationProperties {
     private int maxRetries = 3;
     // FIXME: This configuration is called three different things in this codebase
     private String indexableStudyStatesCsv = "PUBLISHED";
+    private int pageLimit = 100;
   }
 
   @Data

--- a/maestro-app/src/main/resources/config/application.yml
+++ b/maestro-app/src/main/resources/config/application.yml
@@ -15,6 +15,8 @@ maestro:
     maxInMemorySize: -1
   song:
     indexableStudyStatesCsv: PUBLISHED
+    # page limit for getting analysis from song
+    pageLimit: 50
     maxRetries: 3
     timeoutSec:
         study: 100 # some studies take really long, +30 secs, to be downloaded

--- a/maestro-app/src/main/resources/config/application.yml
+++ b/maestro-app/src/main/resources/config/application.yml
@@ -16,7 +16,7 @@ maestro:
   song:
     indexableStudyStatesCsv: PUBLISHED
     # page limit for getting analysis from song
-    pageLimit: 50
+    pageLimit: 100
     maxRetries: 3
     timeoutSec:
         study: 100 # some studies take really long, +30 secs, to be downloaded

--- a/maestro-app/src/main/resources/config/application.yml
+++ b/maestro-app/src/main/resources/config/application.yml
@@ -16,7 +16,7 @@ maestro:
   song:
     indexableStudyStatesCsv: PUBLISHED
     # page limit for getting analysis from song
-    pageLimit: 100
+    pageLimit: 25
     maxRetries: 3
     timeoutSec:
         study: 100 # some studies take really long, +30 secs, to be downloaded

--- a/maestro-app/src/test/java/bio/overture/maestro/app/infra/adapter/outbound/metadata/study/song/SongStudyDAOTest.java
+++ b/maestro-app/src/test/java/bio/overture/maestro/app/infra/adapter/outbound/metadata/study/song/SongStudyDAOTest.java
@@ -144,7 +144,7 @@ class SongStudyDAOTest {
         request(
                 "GET",
                 urlMatching(
-                    "/studies/PEME-CA/analysis/paginated\\?analysisStates=PUBLISHED&limit=100&offset=\\d+"))
+                    "/studies/PEME-CA/analysis/paginated\\?analysisStates=PUBLISHED&limit=25&offset=\\d+"))
             .inScenario("RANDOM_FAILURE")
             .whenScenarioStateIs(Scenario.STARTED)
             .willReturn(
@@ -158,7 +158,7 @@ class SongStudyDAOTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .inScenario("RANDOM_FAILURE")
             .whenScenarioStateIs("WORKING")
             .willReturn(
@@ -171,7 +171,7 @@ class SongStudyDAOTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .inScenario("RANDOM_FAILURE")
             .whenScenarioStateIs("WORKING")
             .willReturn(
@@ -202,7 +202,7 @@ class SongStudyDAOTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(400)
@@ -212,7 +212,7 @@ class SongStudyDAOTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=100"))
             .willReturn(
                 aResponse()
                     .withStatus(400)

--- a/maestro-app/src/test/java/bio/overture/maestro/domain/api/AnalysisCentricIntegrationTest.java
+++ b/maestro-app/src/test/java/bio/overture/maestro/domain/api/AnalysisCentricIntegrationTest.java
@@ -224,17 +224,33 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
                 elasticSearchJsonMapper,
                 Map.of("COLLAB_REPO_URL", applicationProperties.repositories().get(0).getUrl())));
 
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
     for (Study study : studies) {
       val studyId = study.getStudyId();
-      val studyAnalyses = getStudyAnalysesAsString(studyId);
+      val resp = getAnalysisResponse(studyId);
       stubFor(
           request(
                   "GET",
-                  urlEqualTo("/collab/studies/" + studyId + "/analysis?analysisStates=PUBLISHED"))
+                  urlEqualTo(
+                      "/collab/studies/"
+                          + studyId
+                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
               .willReturn(
                   aResponse()
                       .withStatus(200)
-                      .withBody(studyAnalyses)
+                      .withBody(resp)
+                      .withHeader("Content-Type", "application/json")));
+      stubFor(
+          request(
+                  "GET",
+                  urlEqualTo(
+                      "/collab/studies/"
+                          + studyId
+                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+              .willReturn(
+                  aResponse()
+                      .withStatus(200)
+                      .withBody(emptyResp)
                       .withHeader("Content-Type", "application/json")));
     }
 
@@ -275,7 +291,8 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
   void shouldIndexStudyWithExclusionsApplied() throws InterruptedException, IOException {
     // Given
     @SuppressWarnings("all")
-    val analyses = loadJsonString(this.getClass(), "EUCANCAN-BE.studies.json");
+    val analyses = loadJsonString(this.getClass(), "EUCANCAN-BE.response.json");
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
     val expectedDoc0 =
         loadJsonFixture(
             this.getClass(),
@@ -292,11 +309,24 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
             Map.of("COLLAB_REPO_URL", applicationProperties.repositories().get(0).getUrl()));
 
     stubFor(
-        request("GET", urlEqualTo("/collab/studies/EUCANCAN-BE/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withBody(analyses)
+                    .withHeader("Content-Type", "application/json")));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(emptyResp)
                     .withHeader("Content-Type", "application/json")));
 
     // test
@@ -334,6 +364,8 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
   void shouldDeleteSingleAnalysis() throws InterruptedException, IOException {
     @SuppressWarnings("all")
     val collabAnalyses = loadJsonString(this.getClass(), "EUCANCAN-BE.studies.json");
+    val resp = loadJsonString(this.getClass(), "EUCANCAN-BE.response.json");
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
     val expectedDoc0 =
         loadJsonFixture(
             this.getClass(),
@@ -350,10 +382,23 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
             Map.of("COLLAB_REPO_URL", applicationProperties.repositories().get(0).getUrl()));
 
     stubFor(
-        request("GET", urlEqualTo("/collab/studies/EUCANCAN-BE/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
-                    .withBody(collabAnalyses)
+                    .withBody(resp)
+                    .withHeader("Content-Type", "application/json")
+                    .withStatus(200)));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withBody(emptyResp)
                     .withHeader("Content-Type", "application/json")
                     .withStatus(200)));
 
@@ -388,9 +433,11 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
   void shouldUpdateExistingDocRepository() throws InterruptedException, IOException {
     // Given
     @SuppressWarnings("all")
-    val collabAnalyses = loadJsonString(this.getClass(), "EUCANCAN-BE.studies.json");
+    val collabAnalyses = loadJsonString(this.getClass(), "EUCANCAN-BE.response.json");
     @SuppressWarnings("all")
-    val awsStudyAnalyses = loadJsonString(this.getClass(), "EUCANCAN-BE.aws.analysis.json");
+    val awsStudyAnalyses =
+        loadJsonString(this.getClass(), "EUCANCAN-BE.aws.analysis.response.json");
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
 
     val expectedDoc0 =
         loadJsonFixture(
@@ -418,19 +465,45 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
                 "COLLAB_REPO_URL", applicationProperties.repositories().get(0).getUrl(),
                 "AWS_REPO_URL", applicationProperties.repositories().get(1).getUrl()));
     stubFor(
-        request("GET", urlEqualTo("/collab/studies/EUCANCAN-BE/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withBody(collabAnalyses)
                     .withHeader("Content-Type", "application/json")));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(emptyResp)
+                    .withHeader("Content-Type", "application/json")));
 
     stubFor(
-        request("GET", urlEqualTo("/aws/studies/EUCANCAN-BE/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withBody(awsStudyAnalyses)
+                    .withHeader("Content-Type", "application/json")));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(emptyResp)
                     .withHeader("Content-Type", "application/json")));
 
     // test
@@ -475,11 +548,15 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
     // Given
     @SuppressWarnings("all")
     val collabAnalyses = loadJsonString(this.getClass(), "EUCANCAN-BE.studies.json");
+    val resp = loadJsonString(this.getClass(), "EUCANCAN-BE.response.json");
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
 
     // Conflicting analysis 43f07e4d-e26b-4f4a-b07e-4de26b9f4a50 has a different analysis state:
     @SuppressWarnings("all")
     val awsStudyAnalyses =
         loadJsonString(this.getClass(), "EUCANCAN-BE.aws.conflicting.study.json");
+    val awsAnalysisResp =
+        loadJsonString(this.getClass(), "EUCANCAN-BE.aws.conflicting.response.json");
     val awsStudyAnalysesList =
         loadJsonFixture(
             this.getClass(),
@@ -505,19 +582,47 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
             NotificationName.ANALYSIS_CONFLICT,
             getConflicts(expectedDoc1, awsStudyAnalysesList.get(0).getAnalysisId()));
 
+    // stub collab requests:
     stubFor(
-        request("GET", urlEqualTo("/collab/studies/EUCANCAN-BE/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
-                    .withBody(collabAnalyses)
+                    .withBody(resp)
                     .withHeader("Content-Type", "application/json")));
     stubFor(
-        request("GET", urlEqualTo("/aws/studies/EUCANCAN-BE/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
-                    .withBody(awsStudyAnalyses)
+                    .withBody(emptyResp)
+                    .withHeader("Content-Type", "application/json")));
+    // stub aws repo requests:
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(awsAnalysisResp)
+                    .withHeader("Content-Type", "application/json")));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(emptyResp)
                     .withHeader("Content-Type", "application/json")));
 
     // test
@@ -616,6 +721,11 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
   @SneakyThrows
   private String getStudyAnalysesAsString(String studyId) {
     return loadJsonString(getClass(), studyId + ".analysis.json");
+  }
+
+  @SneakyThrows
+  private String getAnalysisResponse(String studyId) {
+    return loadJsonString(getClass(), studyId + ".analysis.response.json");
   }
 
   @NotNull

--- a/maestro-app/src/test/java/bio/overture/maestro/domain/api/AnalysisCentricIntegrationTest.java
+++ b/maestro-app/src/test/java/bio/overture/maestro/domain/api/AnalysisCentricIntegrationTest.java
@@ -234,7 +234,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
                   urlEqualTo(
                       "/collab/studies/"
                           + studyId
-                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
               .willReturn(
                   aResponse()
                       .withStatus(200)
@@ -246,7 +246,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
                   urlEqualTo(
                       "/collab/studies/"
                           + studyId
-                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
               .willReturn(
                   aResponse()
                       .withStatus(200)
@@ -312,7 +312,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -322,7 +322,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -385,7 +385,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withBody(resp)
@@ -395,7 +395,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withBody(emptyResp)
@@ -468,7 +468,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -478,7 +478,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -489,7 +489,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -499,7 +499,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -587,7 +587,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -597,7 +597,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/collab/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -608,7 +608,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -618,7 +618,7 @@ public class AnalysisCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/aws/studies/EUCANCAN-BE/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)

--- a/maestro-app/src/test/java/bio/overture/maestro/domain/api/FileCentricIntegrationTest.java
+++ b/maestro-app/src/test/java/bio/overture/maestro/domain/api/FileCentricIntegrationTest.java
@@ -265,6 +265,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
     // study LIAD-FR and donor DO52693 should be excluded
     // Given
     val studiesArray = loadJsonFixture(this.getClass(), "studies.json", String[].class);
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
     val studies =
         Arrays.stream(studiesArray)
             .map(s -> Study.builder().studyId(s).build())
@@ -284,11 +285,26 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
       stubFor(
           request(
                   "GET",
-                  urlEqualTo("/collab/studies/" + studyId + "/analysis?analysisStates=PUBLISHED"))
+                  urlEqualTo(
+                      "/collab/studies/"
+                          + studyId
+                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
               .willReturn(
                   aResponse()
                       .withStatus(200)
                       .withBody(studyAnalyses)
+                      .withHeader("Content-Type", "application/json")));
+      stubFor(
+          request(
+                  "GET",
+                  urlEqualTo(
+                      "/collab/studies/"
+                          + studyId
+                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+              .willReturn(
+                  aResponse()
+                      .withStatus(200)
+                      .withBody(emptyResp)
                       .withHeader("Content-Type", "application/json")));
     }
 
@@ -329,7 +345,8 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
   void shouldIndexStudyWithExclusionsApplied() throws InterruptedException, IOException {
     // Given
     @SuppressWarnings("all")
-    val analyses = loadJsonString(this.getClass(), "PEME-CA.study.json");
+    val analyses = loadJsonString(this.getClass(), "PEME-CA.study.response.json");
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
     val expectedDoc0 =
         loadJsonFixture(
             this.getClass(),
@@ -346,11 +363,24 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
             Map.of("COLLAB_REPO_URL", applicationProperties.repositories().get(0).getUrl()));
 
     stubFor(
-        request("GET", urlEqualTo("/collab/studies/PEME-CA/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withBody(analyses)
+                    .withHeader("Content-Type", "application/json")));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(emptyResp)
                     .withHeader("Content-Type", "application/json")));
 
     // test
@@ -387,9 +417,11 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
   void shouldDeleteSingleAnalysis() throws InterruptedException, IOException {
     // Given
     @SuppressWarnings("all")
-    val collabAnalyses = loadJsonString(this.getClass(), "PEME-CA.study.json");
+    val collabAnalyses = loadJsonString(this.getClass(), "PEME-CA.study.response.json");
     @SuppressWarnings("all")
-    val awsStudyAnalyses = loadJsonString(this.getClass(), "PEME-CA.aws.study.json");
+    val awsStudyAnalyses = loadJsonString(this.getClass(), "PEME-CA.aws.study.response.json");
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
+
     val expectedDoc0 =
         loadJsonFixture(
             this.getClass(),
@@ -406,17 +438,43 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
             Map.of("COLLAB_REPO_URL", applicationProperties.repositories().get(0).getUrl()));
 
     stubFor(
-        request("GET", urlEqualTo("/collab/studies/PEME-CA/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withBody(collabAnalyses)
                     .withHeader("Content-Type", "application/json")
                     .withStatus(200)));
     stubFor(
-        request("GET", urlEqualTo("/aws/studies/PEME-CA/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withBody(emptyResp)
+                    .withHeader("Content-Type", "application/json")
+                    .withStatus(200)));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withBody(awsStudyAnalyses)
+                    .withHeader("Content-Type", "application/json")
+                    .withStatus(200)));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withBody(emptyResp)
                     .withHeader("Content-Type", "application/json")
                     .withStatus(200)));
 
@@ -450,10 +508,10 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
   void shouldUpdateExistingFileDocRepository() throws InterruptedException, IOException {
     // Given
     @SuppressWarnings("all")
-    val collabAnalyses = loadJsonString(this.getClass(), "PEME-CA.study.json");
+    val collabAnalyses = loadJsonString(this.getClass(), "PEME-CA.study.response.json");
     @SuppressWarnings("all")
-    val awsStudyAnalyses = loadJsonString(this.getClass(), "PEME-CA.aws.study.json");
-
+    val awsStudyAnalyses = loadJsonString(this.getClass(), "PEME-CA.aws.study.response.json");
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
     val expectedDoc0 =
         loadJsonFixture(
             this.getClass(),
@@ -480,19 +538,45 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
                 "COLLAB_REPO_URL", applicationProperties.repositories().get(0).getUrl(),
                 "AWS_REPO_URL", applicationProperties.repositories().get(1).getUrl()));
     stubFor(
-        request("GET", urlEqualTo("/collab/studies/PEME-CA/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withBody(collabAnalyses)
                     .withHeader("Content-Type", "application/json")));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(emptyResp)
+                    .withHeader("Content-Type", "application/json")));
 
     stubFor(
-        request("GET", urlEqualTo("/aws/studies/PEME-CA/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withBody(awsStudyAnalyses)
+                    .withHeader("Content-Type", "application/json")));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(emptyResp)
                     .withHeader("Content-Type", "application/json")));
 
     // test
@@ -534,11 +618,13 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
   void shouldDetectAndNotifyConflictingDocuments() throws InterruptedException, IOException {
     // Given
     @SuppressWarnings("all")
-    val collabAnalyses = loadJsonString(this.getClass(), "PEME-CA.study.json");
+    val collabAnalyses = loadJsonString(this.getClass(), "PEME-CA.study.response.json");
+    val emptyResp = loadJsonString(this.getClass(), "empty-response.json");
 
     // this has a different analysis id than the one in previous files
     @SuppressWarnings("all")
-    val awsStudyAnalyses = loadJsonString(this.getClass(), "PEME-CA.aws.conflicting.study.json");
+    val awsStudyAnalyses =
+        loadJsonString(this.getClass(), "PEME-CA.aws.conflicting.study.response.json");
     val awsStudyAnalysesList =
         loadJsonFixture(
             this.getClass(),
@@ -565,18 +651,44 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
             getConflicts(expectedDoc1, awsStudyAnalysesList.get(0).getAnalysisId()));
 
     stubFor(
-        request("GET", urlEqualTo("/collab/studies/PEME-CA/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withBody(collabAnalyses)
                     .withHeader("Content-Type", "application/json")));
     stubFor(
-        request("GET", urlEqualTo("/aws/studies/PEME-CA/analysis?analysisStates=PUBLISHED"))
+        request(
+                "GET",
+                urlEqualTo(
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(emptyResp)
+                    .withHeader("Content-Type", "application/json")));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withBody(awsStudyAnalyses)
+                    .withHeader("Content-Type", "application/json")));
+    stubFor(
+        request(
+                "GET",
+                urlEqualTo(
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(emptyResp)
                     .withHeader("Content-Type", "application/json")));
 
     // test
@@ -694,6 +806,6 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
 
   @SneakyThrows
   private String getStudyAnalysesAsString(String studyId) {
-    return loadJsonString(getClass(), studyId + ".analysis.json");
+    return loadJsonString(getClass(), studyId + ".analysis.response.json");
   }
 }

--- a/maestro-app/src/test/java/bio/overture/maestro/domain/api/FileCentricIntegrationTest.java
+++ b/maestro-app/src/test/java/bio/overture/maestro/domain/api/FileCentricIntegrationTest.java
@@ -288,7 +288,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
                   urlEqualTo(
                       "/collab/studies/"
                           + studyId
-                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
               .willReturn(
                   aResponse()
                       .withStatus(200)
@@ -300,7 +300,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
                   urlEqualTo(
                       "/collab/studies/"
                           + studyId
-                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                          + "/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
               .willReturn(
                   aResponse()
                       .withStatus(200)
@@ -366,7 +366,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -376,7 +376,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -441,7 +441,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withBody(collabAnalyses)
@@ -451,7 +451,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withBody(emptyResp)
@@ -461,7 +461,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withBody(awsStudyAnalyses)
@@ -471,7 +471,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withBody(emptyResp)
@@ -541,7 +541,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -551,7 +551,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -562,7 +562,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -572,7 +572,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -654,7 +654,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -664,7 +664,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/collab/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -674,7 +674,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=0"))
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=0"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -684,7 +684,7 @@ class FileCentricIntegrationTest extends MaestroIntegrationTest {
         request(
                 "GET",
                 urlEqualTo(
-                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=100&offset=100"))
+                    "/aws/studies/PEME-CA/analysis/paginated?analysisStates=PUBLISHED&limit=25&offset=25"))
             .willReturn(
                 aResponse()
                     .withStatus(200)

--- a/maestro-app/src/test/resources/config/application.yml
+++ b/maestro-app/src/test/resources/config/application.yml
@@ -15,7 +15,7 @@ maestro:
   song:
     indexableStudyStatus: PUBLISHED
     maxRetries: 3
-    pageLimit: 100
+    pageLimit: 25
     timeoutSec:
       study: 5
       analysis: 5

--- a/maestro-app/src/test/resources/config/application.yml
+++ b/maestro-app/src/test/resources/config/application.yml
@@ -15,6 +15,7 @@ maestro:
   song:
     indexableStudyStatus: PUBLISHED
     maxRetries: 3
+    pageLimit: 100
     timeoutSec:
       study: 5
       analysis: 5

--- a/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/DASH-CA.analysis.response.json
+++ b/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/DASH-CA.analysis.response.json
@@ -1,0 +1,79 @@
+{
+  "analyses":
+  [
+    {
+      "analysisId": "a07fe97f-80e1-4e69-bfe9-7f80e18e6969",
+      "studyId": "DASH-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "sampleId": "SA619219",
+          "specimenId": "SP219218",
+          "submitterSampleId": "dashsa-1",
+          "matchedNormalSubmitterSampleId": null,
+          "sampleType": "Amplified DNA",
+          "specimen": {
+            "specimenId": "SP219218",
+            "donorId": "DO259142",
+            "submitterSpecimenId": "dashsp-1",
+            "tumourNormalDesignation": "Normal",
+            "specimenTissueSource": "Blood derived",
+            "specimenType": "Normal"
+          },
+          "donor": {
+            "donorId": "DO259142",
+            "studyId": "DASH-CA",
+            "gender": "Male",
+            "submitterDonorId": "DASH-1"
+          }
+        }
+      ],
+      "files": [
+        {
+          "objectId": "fc019c84-dc29-5362-8069-dee7aea67735",
+          "studyId": "DASH-CA",
+          "analysisId": "a07fe97f-80e1-4e69-bfe9-7f80e18e6969",
+          "fileName": "dash-1-normal.bam",
+          "fileSize": 24,
+          "fileType": "BAM",
+          "fileMd5sum": "4d6e35e3290ccce08c8c7517dc29d624",
+          "fileAccess": "controlled",
+          "dataType": "Submitted Reads"
+        }
+      ],
+      "analysisType": {
+        "name": "sequencing_experiment",
+        "version": 3
+      },
+      "experiment": {
+        "platform": "ILLUMINA",
+        "platform_model": null,
+        "sequencing_date": null,
+        "sequencing_center": null,
+        "experimental_strategy": "WGS",
+        "submitter_sequencing_experiment_id": "DASH-SE-1"
+      },
+      "read_groups": [
+        {
+          "file_r1": "dash-1-normal.bam",
+          "file_r2": null,
+          "insert_size": null,
+          "library_name": "Dashboard-Testing",
+          "is_paired_end": false,
+          "platform_unit": "Dashboard-Testing",
+          "read_length_r1": null,
+          "read_length_r2": null,
+          "sample_barcode": null,
+          "submitter_read_group_id": "dash-1-rg-1"
+        }
+      ],
+      "read_group_count": 1
+    }
+  ],
+  "totalAnalyses": 1,
+  "currentTotalAnalyses": 1
+}
+

--- a/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/EUCANCAN-BE.aws.analysis.response.json
+++ b/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/EUCANCAN-BE.aws.analysis.response.json
@@ -1,0 +1,92 @@
+{
+  "analyses":
+  [
+    {
+      "analysisId": "43f07e4d-e26b-4f4a-b07e-4de26b9f4a50",
+      "studyId": "EUCANCAN-BE",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "sampleId": "SA610334",
+          "specimenId": "SP210307",
+          "submitterSampleId": "insilico_2_tumor",
+          "matchedNormalSubmitterSampleId": "insilico_2_normal",
+          "sampleType": "Total DNA",
+          "specimen": {
+            "specimenId": "SP210307",
+            "donorId": "DO250284",
+            "submitterSpecimenId": "insilico_2_tumor",
+            "tumourNormalDesignation": "Tumour",
+            "specimenTissueSource": "Blood derived",
+            "specimenType": "Primary tumour"
+          },
+          "donor": {
+            "donorId": "DO250284",
+            "studyId": "EUCANCAN-BE",
+            "gender": "Female",
+            "submitterDonorId": "insilico_2"
+          }
+        }
+      ],
+      "files": [
+        {
+          "objectId": "882e4591-b004-5564-b2ec-1a210f8cba6b",
+          "studyId": "EUCANCAN-BE",
+          "analysisId": "43f07e4d-e26b-4f4a-b07e-4de26b9f4a50",
+          "fileName": "EUCANCAN-BE.DO250284.SA610334.wgs.20200413.sanger-wgs.somatic.snv.vcf.gz",
+          "fileSize": 927567,
+          "fileType": "VCF",
+          "fileMd5sum": "0d38c7ed8d5ca347deca7b5ef155823b",
+          "fileAccess": "controlled",
+          "dataType": "somatic_snv"
+        },
+        {
+          "objectId": "c6d6eee4-a2cd-513d-a8e5-4d06098d54fe",
+          "studyId": "EUCANCAN-BE",
+          "analysisId": "43f07e4d-e26b-4f4a-b07e-4de26b9f4a50",
+          "fileName": "EUCANCAN-BE.DO250284.SA610334.wgs.20200413.sanger-wgs.somatic.snv.vcf.gz.tbi",
+          "fileSize": 168704,
+          "fileType": "TBI",
+          "fileMd5sum": "acd5e3780a91ed0364af7ce8106edd3d",
+          "fileAccess": "controlled",
+          "dataType": "vcf_index"
+        }
+      ],
+      "analysisType": {
+        "name": "variant_calling",
+        "version": 2
+      },
+      "workflow": {
+        "name": "sanger-wgs-variant-calling",
+        "inputs": [
+          {
+            "analysis_type": "sequencing_alignment",
+            "tumour_analysis_id": "13b13548-6e32-412d-b135-486e32512dbe"
+          },
+          {
+            "analysis_type": "sequencing_alignment",
+            "normal_analysis_id": "0efe5aeb-3e21-48a5-be5a-eb3e2118a502"
+          }
+        ],
+        "run_id": "wise_brown",
+        "version": "0.1.0-dev",
+        "short_name": "sanger-wgs"
+      },
+      "experiment": {
+        "library_strategy": "WGS"
+      },
+      "variant_type": [
+        "snv"
+      ],
+      "variant_class": [
+        "somatic"
+      ]
+    }
+  ],
+  "totalAnalyses": 1,
+  "currentTotalAnalyses": 1
+}
+

--- a/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/EUCANCAN-BE.aws.conflicting.response.json
+++ b/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/EUCANCAN-BE.aws.conflicting.response.json
@@ -1,0 +1,92 @@
+{
+  "analyses":
+  [
+    {
+      "analysisId": "43f07e4d-e26b-4f4a-b07e-4de26b9f4a50",
+      "studyId": "EUCANCAN-BE",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "sampleId": "SA610334",
+          "specimenId": "SP210307",
+          "submitterSampleId": "insilico_2_tumor",
+          "matchedNormalSubmitterSampleId": "insilico_2_normal",
+          "sampleType": "Total DNA",
+          "specimen": {
+            "specimenId": "SP210307",
+            "donorId": "DO250284",
+            "submitterSpecimenId": "insilico_2_tumor",
+            "tumourNormalDesignation": "Tumour",
+            "specimenTissueSource": "Blood derived",
+            "specimenType": "Primary tumour"
+          },
+          "donor": {
+            "donorId": "DO250284",
+            "studyId": "EUCANCAN-BE",
+            "gender": "Female",
+            "submitterDonorId": "insilico_2"
+          }
+        }
+      ],
+      "files": [
+        {
+          "objectId": "882e4591-b004-5564-b2ec-1a210f8cba6b",
+          "studyId": "EUCANCAN-BE",
+          "analysisId": "43f07e4d-e26b-4f4a-b07e-4de26b9f4a50",
+          "fileName": "EUCANCAN-BE.DO250284.SA610334.wgs.20200413.sanger-wgs.somatic.snv.vcf.gz",
+          "fileSize": 927567,
+          "fileType": "VCF",
+          "fileMd5sum": "0d38c7ed8d5ca347deca7b5ef155823b",
+          "fileAccess": "controlled",
+          "dataType": "somatic_snv"
+        },
+        {
+          "objectId": "c6d6eee4-a2cd-513d-a8e5-4d06098d54fe",
+          "studyId": "EUCANCAN-BE",
+          "analysisId": "43f07e4d-e26b-4f4a-b07e-4de26b9f4a50",
+          "fileName": "EUCANCAN-BE.DO250284.SA610334.wgs.20200413.sanger-wgs.somatic.snv.vcf.gz.tbi",
+          "fileSize": 168704,
+          "fileType": "TBI",
+          "fileMd5sum": "acd5e3780a91ed0364af7ce8106edd3d",
+          "fileAccess": "controlled",
+          "dataType": "vcf_index"
+        }
+      ],
+      "analysisType": {
+        "name": "sequencingRead",
+        "version": 2
+      },
+      "workflow": {
+        "name": "sanger-wgs-variant-calling",
+        "inputs": [
+          {
+            "analysis_type": "sequencing_alignment",
+            "tumour_analysis_id": "13b13548-6e32-412d-b135-486e32512dbe"
+          },
+          {
+            "analysis_type": "sequencing_alignment",
+            "normal_analysis_id": "0efe5aeb-3e21-48a5-be5a-eb3e2118a502"
+          }
+        ],
+        "run_id": "wise_brown",
+        "version": "0.1.0-dev",
+        "short_name": "sanger-wgs"
+      },
+      "experiment": {
+        "library_strategy": "WGS"
+      },
+      "variant_type": [
+        "snv"
+      ],
+      "variant_class": [
+        "somatic"
+      ]
+    }
+  ],
+  "totalAnalyses": 1,
+  "currentTotalAnalyses": 1
+}
+

--- a/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/EUCANCAN-BE.response.json
+++ b/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/EUCANCAN-BE.response.json
@@ -1,0 +1,176 @@
+{
+  "analyses":
+  [
+    {
+      "analysisId": "cf1432f7-985e-4858-9432-f7985ee858e4",
+      "studyId": "EUCANCAN-BE",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "sampleId": "SA610334",
+          "specimenId": "SP210307",
+          "submitterSampleId": "insilico_2_tumor",
+          "matchedNormalSubmitterSampleId": "insilico_2_normal",
+          "sampleType": "Total DNA",
+          "specimen": {
+            "specimenId": "SP210307",
+            "donorId": "DO250284",
+            "submitterSpecimenId": "insilico_2_tumor",
+            "tumourNormalDesignation": "Tumour",
+            "specimenTissueSource": "Blood derived",
+            "specimenType": "Primary tumour"
+          },
+          "donor": {
+            "donorId": "DO250284",
+            "studyId": "EUCANCAN-BE",
+            "gender": "Female",
+            "submitterDonorId": "insilico_2"
+          }
+        }
+      ],
+      "files": [
+        {
+          "objectId": "94ef9598-537f-574b-842d-1486fac84ade",
+          "studyId": "EUCANCAN-BE",
+          "analysisId": "cf1432f7-985e-4858-9432-f7985ee858e4",
+          "fileName": "EUCANCAN-BE.DO250284.SA610334.wgs.20200413.sanger-wgs.somatic.sv.vcf.gz",
+          "fileSize": 695576,
+          "fileType": "VCF",
+          "fileMd5sum": "f8f8dc5a4899b927fe565183a0798a2a",
+          "fileAccess": "controlled",
+          "dataType": "somatic_sv"
+        },
+        {
+          "objectId": "f215e48c-2d76-5c32-b920-20a95305801f",
+          "studyId": "EUCANCAN-BE",
+          "analysisId": "cf1432f7-985e-4858-9432-f7985ee858e4",
+          "fileName": "EUCANCAN-BE.DO250284.SA610334.wgs.20200413.sanger-wgs.somatic.sv.vcf.gz.tbi",
+          "fileSize": 11732,
+          "fileType": "TBI",
+          "fileMd5sum": "a48ef040c536807e6bf7107a216b54f2",
+          "fileAccess": "controlled",
+          "dataType": "vcf_index"
+        }
+      ],
+      "analysisType": {
+        "name": "variant_calling",
+        "version": 2
+      },
+      "workflow": {
+        "name": "sanger-wgs-variant-calling",
+        "inputs": [
+          {
+            "analysis_type": "sequencing_alignment",
+            "tumour_analysis_id": "13b13548-6e32-412d-b135-486e32512dbe"
+          },
+          {
+            "analysis_type": "sequencing_alignment",
+            "normal_analysis_id": "0efe5aeb-3e21-48a5-be5a-eb3e2118a502"
+          }
+        ],
+        "run_id": "wise_brown",
+        "version": "0.1.0-dev",
+        "short_name": "sanger-wgs"
+      },
+      "experiment": {
+        "library_strategy": "WGS"
+      },
+      "variant_type": [
+        "sv"
+      ],
+      "variant_class": [
+        "somatic"
+      ]
+    },
+    {
+      "analysisId": "43f07e4d-e26b-4f4a-b07e-4de26b9f4a50",
+      "studyId": "EUCANCAN-BE",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "sampleId": "SA610334",
+          "specimenId": "SP210307",
+          "submitterSampleId": "insilico_2_tumor",
+          "matchedNormalSubmitterSampleId": "insilico_2_normal",
+          "sampleType": "Total DNA",
+          "specimen": {
+            "specimenId": "SP210307",
+            "donorId": "DO250284",
+            "submitterSpecimenId": "insilico_2_tumor",
+            "tumourNormalDesignation": "Tumour",
+            "specimenTissueSource": "Blood derived",
+            "specimenType": "Primary tumour"
+          },
+          "donor": {
+            "donorId": "DO250284",
+            "studyId": "EUCANCAN-BE",
+            "gender": "Female",
+            "submitterDonorId": "insilico_2"
+          }
+        }
+      ],
+      "files": [
+        {
+          "objectId": "882e4591-b004-5564-b2ec-1a210f8cba6b",
+          "studyId": "EUCANCAN-BE",
+          "analysisId": "43f07e4d-e26b-4f4a-b07e-4de26b9f4a50",
+          "fileName": "EUCANCAN-BE.DO250284.SA610334.wgs.20200413.sanger-wgs.somatic.snv.vcf.gz",
+          "fileSize": 927567,
+          "fileType": "VCF",
+          "fileMd5sum": "0d38c7ed8d5ca347deca7b5ef155823b",
+          "fileAccess": "controlled",
+          "dataType": "somatic_snv"
+        },
+        {
+          "objectId": "c6d6eee4-a2cd-513d-a8e5-4d06098d54fe",
+          "studyId": "EUCANCAN-BE",
+          "analysisId": "43f07e4d-e26b-4f4a-b07e-4de26b9f4a50",
+          "fileName": "EUCANCAN-BE.DO250284.SA610334.wgs.20200413.sanger-wgs.somatic.snv.vcf.gz.tbi",
+          "fileSize": 168704,
+          "fileType": "TBI",
+          "fileMd5sum": "acd5e3780a91ed0364af7ce8106edd3d",
+          "fileAccess": "controlled",
+          "dataType": "vcf_index"
+        }
+      ],
+      "analysisType": {
+        "name": "variant_calling",
+        "version": 2
+      },
+      "workflow": {
+        "name": "sanger-wgs-variant-calling",
+        "inputs": [
+          {
+            "analysis_type": "sequencing_alignment",
+            "tumour_analysis_id": "13b13548-6e32-412d-b135-486e32512dbe"
+          },
+          {
+            "analysis_type": "sequencing_alignment",
+            "normal_analysis_id": "0efe5aeb-3e21-48a5-be5a-eb3e2118a502"
+          }
+        ],
+        "run_id": "wise_brown",
+        "version": "0.1.0-dev",
+        "short_name": "sanger-wgs"
+      },
+      "experiment": {
+        "library_strategy": "WGS"
+      },
+      "variant_type": [
+        "snv"
+      ],
+      "variant_class": [
+        "somatic"
+      ]
+    }
+  ],
+  "totalAnalyses": 2,
+  "currentTotalAnalyses": 2
+}
+

--- a/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/OCCAMS-GB.analysis.response.json
+++ b/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/OCCAMS-GB.analysis.response.json
@@ -1,0 +1,90 @@
+{
+  "analyses":
+  [
+    {
+      "analysisId": "6332d367-dc6a-4994-b2d3-67dc6a9994d0",
+      "studyId": "OCCAMS-GB",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "sampleId": "SA528813",
+          "specimenId": "SP111002",
+          "submitterSampleId": "LP6007504-DNA_A01",
+          "matchedNormalSubmitterSampleId": "LP6007566-DNA_A01",
+          "sampleType": "Total DNA",
+          "specimen": {
+            "specimenId": "SP111002",
+            "donorId": "DO50327",
+            "submitterSpecimenId": "COU1-0084-lesion-30-3-11-A-",
+            "tumourNormalDesignation": "Tumour",
+            "specimenTissueSource": "Solid tissue",
+            "specimenType": "Primary tumour"
+          },
+          "donor": {
+            "donorId": "DO50327",
+            "studyId": "OCCAMS-GB",
+            "gender": "Male",
+            "submitterDonorId": "OCCAMS-AH-021"
+          }
+        }
+      ],
+      "files": [
+        {
+          "objectId": "43d4f83b-1a18-5868-8a44-5e3a6930e89c",
+          "studyId": "OCCAMS-GB",
+          "analysisId": "6332d367-dc6a-4994-b2d3-67dc6a9994d0",
+          "fileName": "OCCAMS-GB.DO50327.SA528813.wgs.20200409.sanger-wgs.somatic.snv.vcf.gz",
+          "fileSize": 8857968,
+          "fileType": "VCF",
+          "fileMd5sum": "2d43e6fa316aa12db74fd6c862939139",
+          "fileAccess": "controlled",
+          "dataType": "somatic_snv"
+        },
+        {
+          "objectId": "7c943e62-7d92-545a-837a-c6b7b57bb930",
+          "studyId": "OCCAMS-GB",
+          "analysisId": "6332d367-dc6a-4994-b2d3-67dc6a9994d0",
+          "fileName": "OCCAMS-GB.DO50327.SA528813.wgs.20200409.sanger-wgs.somatic.snv.vcf.gz.tbi",
+          "fileSize": 536077,
+          "fileType": "TBI",
+          "fileMd5sum": "6fc6cda076c91f909174b9df69c939d7",
+          "fileAccess": "controlled",
+          "dataType": "vcf_index"
+        }
+      ],
+      "analysisType": {
+        "name": "variant_calling",
+        "version": 2
+      },
+      "workflow": {
+        "name": "sanger-wgs-variant-calling",
+        "inputs": [
+          {
+            "analysis_type": "sequencing_alignment",
+            "tumour_analysis_id": "04a2db76-f3ef-415d-a2db-76f3ef615d1b"
+          },
+          {
+            "analysis_type": "sequencing_alignment",
+            "normal_analysis_id": "77e7ba17-2aee-40f9-a7ba-172aee60f92c"
+          }
+        ],
+        "run_id": "naughty_galileo",
+        "version": "0.1.0-dev",
+        "short_name": "sanger-wgs"
+      },
+      "experiment": {
+        "library_strategy": "WGS"
+      },
+      "variant_type": [
+        "snv"
+      ],
+      "variant_class": "somatic"
+    }
+  ],
+  "totalAnalyses": 1,
+  "currentTotalAnalyses": 1
+}
+

--- a/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/TEST-CA.analysis.response.json
+++ b/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/TEST-CA.analysis.response.json
@@ -1,0 +1,77 @@
+{
+  "analyses":
+  [
+    {
+      "analysisId": "d0b62734-d955-4b74-b627-34d955eb745e",
+      "studyId": "TEST-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "sampleId": "SA610512",
+          "specimenId": "SP210509",
+          "submitterSampleId": "DEMO_SA_1",
+          "matchedNormalSubmitterSampleId": "sample_x24_11a",
+          "sampleType": "Total RNA",
+          "specimen": {
+            "specimenId": "SP210509",
+            "donorId": "DO250326",
+            "submitterSpecimenId": "DEMO_SP_1",
+            "tumourNormalDesignation": "Tumour",
+            "specimenTissueSource": "Solid tissue",
+            "specimenType": "Primary tumour"
+          },
+          "donor": {
+            "donorId": "DO250326",
+            "studyId": "TEST-CA",
+            "gender": "Female",
+            "submitterDonorId": "DEMO_DO_1"
+          }
+        }
+      ],
+      "files": [
+        {
+          "objectId": "5230eb04-6702-5e11-ade3-9dc8abbe69a0",
+          "studyId": "TEST-CA",
+          "analysisId": "d0b62734-d955-4b74-b627-34d955eb745e",
+          "fileName": "example.vcf.gz",
+          "fileSize": 52,
+          "fileType": "VCF",
+          "fileMd5sum": "9a793e90d0d1e11301ea8da996446e59",
+          "fileAccess": "open",
+          "dataType": "SOME_DATA_TYPE"
+        },
+        {
+          "info": {
+            "rob": "somevalue2"
+          },
+          "objectId": "30ab4c21-a514-5d86-a127-3dc6e17a567c",
+          "studyId": "TEST-CA",
+          "analysisId": "d0b62734-d955-4b74-b627-34d955eb745e",
+          "fileName": "example.vcf.gz.idx",
+          "fileSize": 25,
+          "fileType": "IDX",
+          "fileMd5sum": "c03274816eb4907a92b8e5632cd6eb81",
+          "fileAccess": "controlled",
+          "dataType": "robdatatype2"
+        }
+      ],
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      },
+      "info": {
+        "description": "This is extra info in a JSON format"
+      },
+      "experiment": {
+        "variantCallingTool": "silver bullet",
+        "matchedNormalSampleSubmitterId": "sample_x24_11a"
+      }
+    }
+  ],
+  "totalAnalyses": 1,
+  "currentTotalAnalyses": 1
+}
+

--- a/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/empty-response.json
+++ b/maestro-app/src/test/resources/fixtures/AnalysisCentricIntegrationTest/empty-response.json
@@ -1,0 +1,7 @@
+{
+  "analyses":
+  [
+  ],
+  "totalAnalyses": 2,
+  "currentTotalAnalyses": 0
+}

--- a/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/LIAD-FR.analysis.response.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/LIAD-FR.analysis.response.json
@@ -1,0 +1,78 @@
+{
+  "analyses":
+  [
+    {
+      "analysisType": {
+        "name": "sequencingRead",
+        "version": 1
+      },
+      "info": {
+        "dcc_project_code": "LIAD-FR",
+        "isPcawg": false
+      },
+      "analysisId": "EGAR00001165965",
+      "studyId": "LIAD-FR",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA520689",
+          "specimenId": "SP109375",
+          "submitterSampleId": "CHC1124T",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP109375",
+            "donorId": "DO49691",
+            "submitterSpecimenId": "CHC1124T",
+            "specimenType": "Primary tumour - solid tissue"
+          },
+          "donor": {
+            "donorId": "DO49691",
+            "submitterDonorId": "CHC1124",
+            "studyId": "LIAD-FR",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "71729c60-d87a-5458-a88c-38e6dc294733",
+          "studyId": "LIAD-FR",
+          "analysisId": "EGAR00001165965",
+          "fileName": "bundle.EGAR00001165965.xml",
+          "fileSize": 8904,
+          "fileType": "XML",
+          "fileMd5sum": "7243c2e2fa5cbabea1ad9d5e9972524a",
+          "fileAccess": "open",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "cf8d06de-f994-5b32-ad1d-ea815f037fd2",
+          "studyId": "LIAD-FR",
+          "analysisId": "EGAR00001165965",
+          "fileName": "d309e3cdd1fc38b0fa8b5486a48e4b94.CHC1124T.sorted.bam",
+          "fileSize": 7494108451,
+          "fileType": "BAM",
+          "fileMd5sum": "d309e3cdd1fc38b0fa8b5486a48e4b94",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "analysisId": "EGAR00001165965",
+        "aligned": false,
+        "libraryStrategy": "WXS",
+        "info": {}
+      }
+    }
+  ],
+  "totalAnalyses": 1,
+  "currentTotalAnalyses": 1
+}

--- a/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/LIRI-JP.analysis.response.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/LIRI-JP.analysis.response.json
@@ -1,0 +1,607 @@
+{
+  "analyses":
+  [
+    {
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      },
+      "info": {},
+      "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+      "studyId": "LIRI-JP",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA515389",
+          "specimenId": "SP107109",
+          "submitterSampleId": "RK202_C01",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP107109",
+            "donorId": "DO48736",
+            "submitterSpecimenId": "RK202_C01",
+            "specimenType": "Primary tumour - solid tissue"
+          },
+          "donor": {
+            "donorId": "DO48736",
+            "submitterDonorId": "RK202",
+            "studyId": "LIRI-JP",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "b63dff38-e239-5a5d-9c36-ec851049fd12",
+          "studyId": "LIRI-JP",
+          "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+          "fileName": "1fd69adc-c623-11e3-bf01-24c6515278c0.svcp_1-0-6.20150511.somatic.indel.vcf.gz",
+          "fileSize": 44440835,
+          "fileType": "VCF",
+          "fileMd5sum": "93354882b0fc014b49be1b24df8f435e",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "eb2832eb-ad54-574b-bb60-1abf74489ed8",
+          "studyId": "LIRI-JP",
+          "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+          "fileName": "1fd69adc-c623-11e3-bf01-24c6515278c0.svcp_1-0-6.20150511.somatic.indel.vcf.gz.tbi",
+          "fileSize": 1458418,
+          "fileType": "TBI",
+          "fileMd5sum": "ade04a5fd0e9d4052b0ec0b280a9be60",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "feecfb7d-2aa9-5434-a0a0-56a6c5ee4a70",
+          "studyId": "LIRI-JP",
+          "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+          "fileName": "1fd69adc-c623-11e3-bf01-24c6515278c0.svfix2_4-0-12.20160209.somatic.sv.vcf.gz",
+          "fileSize": 11431,
+          "fileType": "VCF",
+          "fileMd5sum": "ae2e0a8eb02414569fa06cd56a3e809e",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "e14e73a5-a869-5b9a-a89c-be77fa54135e",
+          "studyId": "LIRI-JP",
+          "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+          "fileName": "1fd69adc-c623-11e3-bf01-24c6515278c0.svfix2_4-0-12.20160209.somatic.sv.vcf.gz.tbi",
+          "fileSize": 1756,
+          "fileType": "TBI",
+          "fileMd5sum": "9ce7cdedb7450a05c03e419235ed56a6",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "3106300b-3666-52b7-a3fa-a5096a51814b",
+          "studyId": "LIRI-JP",
+          "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+          "fileName": "1fd69adc-c623-11e3-bf01-24c6515278c0.svcp_1-0-6.20150511.somatic.cnv.vcf.gz",
+          "fileSize": 3648,
+          "fileType": "VCF",
+          "fileMd5sum": "492989e81699bd5a56b7956e0be7416d",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "ad4e821d-1908-5e37-8b09-f2bcbe841a6b",
+          "studyId": "LIRI-JP",
+          "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+          "fileName": "1fd69adc-c623-11e3-bf01-24c6515278c0.svcp_1-0-6.20150511.somatic.cnv.vcf.gz.tbi",
+          "fileSize": 5539,
+          "fileType": "TBI",
+          "fileMd5sum": "acdf137ad635f95ee93412fa9153d066",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "bed33bd4-eec1-5905-8480-5def36d7f6de",
+          "studyId": "LIRI-JP",
+          "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+          "fileName": "1fd69adc-c623-11e3-bf01-24c6515278c0.svcp_1-0-6.20150511.somatic.snv_mnv.vcf.gz",
+          "fileSize": 1418099,
+          "fileType": "VCF",
+          "fileMd5sum": "1f3cfd1e1ad462cff9871eb2373935ac",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "deab15a3-6820-5bcc-926a-bca2ab5ddaa0",
+          "studyId": "LIRI-JP",
+          "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+          "fileName": "1fd69adc-c623-11e3-bf01-24c6515278c0.svcp_1-0-6.20150511.somatic.snv_mnv.vcf.gz.tbi",
+          "fileSize": 236926,
+          "fileType": "TBI",
+          "fileMd5sum": "2233fb90872d759d279395b1a7ad3461",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "233bc863-114c-5ec4-842b-7f44d189eab0",
+          "studyId": "LIRI-JP",
+          "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+          "fileName": "909614f0-ceeb-11e5-8498-af7e4d100685.xml",
+          "fileSize": 58853,
+          "fileType": "XML",
+          "fileMd5sum": "4f8a5a5a1a040f7538760c3b8b944c86",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "info": {},
+        "analysisId": "909614f0-ceeb-11e5-8498-af7e4d100685",
+        "variantCallingTool": "Sanger variant call pipeline",
+        "matchedNormalSampleSubmitterId": "RK202_B01"
+      }
+    },
+    {
+      "info": {},
+      "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+      "studyId": "LIRI-JP",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA270462",
+          "specimenId": "SP50179",
+          "submitterSampleId": "RK156_C01",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP50179",
+            "donorId": "DO23549",
+            "submitterSpecimenId": "RK156_C01",
+            "specimenType": "Primary tumour - solid tissue"
+          },
+          "donor": {
+            "donorId": "DO23549",
+            "submitterDonorId": "RK156",
+            "studyId": "LIRI-JP",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "24329157-e218-5854-8f45-7fa6b9e046c6",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-snowman-10.20151220.germline.indel.vcf.gz",
+          "fileSize": 10536170,
+          "fileType": "VCF",
+          "fileMd5sum": "7d0676c6a85696e1cb2919836b0ab71e",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "ad8a45f3-ec8d-5391-ae93-b19dc982698a",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-snowman-10.20151220.germline.indel.vcf.gz.idx",
+          "fileSize": 1031078,
+          "fileType": "IDX",
+          "fileMd5sum": "8269ee64b80e6ec66e590767f697d37b",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "4d070189-bd33-5391-b7af-ea32c6782875",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-dRanger_snowman-10.20151220.somatic.sv.vcf.gz",
+          "fileSize": 59633,
+          "fileType": "VCF",
+          "fileMd5sum": "1d0a8bcf2abf8373c6f8cc63cb748aa8",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "14e94abe-1fd1-5a85-8d26-a7291edd80ef",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-dRanger_snowman-10.20151220.somatic.sv.vcf.gz.idx",
+          "fileSize": 11325,
+          "fileType": "IDX",
+          "fileMd5sum": "fdb961feac82a7912bf657450e02c44d",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "107c83c7-595e-5b36-957b-ae706611d5b9",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-snowman-10.20151220.somatic.sv.vcf.gz",
+          "fileSize": 51548,
+          "fileType": "VCF",
+          "fileMd5sum": "fc246f5e1f670b1f756b8e4294f59504",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "c5496778-0d72-5cc6-aac4-98777cfbc0c2",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-snowman-10.20151220.somatic.sv.vcf.gz.idx",
+          "fileSize": 10447,
+          "fileType": "IDX",
+          "fileMd5sum": "5aeb4749609bd0a4d81ecffd673a36e1",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "da524891-37af-5a21-9867-c6812018aa22",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-snowman-10.20151220.germline.sv.vcf.gz",
+          "fileSize": 1710383,
+          "fileType": "VCF",
+          "fileMd5sum": "1f22fff9e578244ba16762a4c82792e8",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "d87c4599-bba4-5c23-b7a2-57bbeed7eacb",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-snowman-10.20151220.germline.sv.vcf.gz.idx",
+          "fileSize": 61514,
+          "fileType": "IDX",
+          "fileMd5sum": "ade5449b588c81496e4e7d2b0b49e3d0",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "46194bd5-b131-55f7-b7b1-99293ba1d6b9",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-snowman-10.20151220.somatic.indel.vcf.gz",
+          "fileSize": 31242,
+          "fileType": "VCF",
+          "fileMd5sum": "e75eef7af227c5c80d0b499ffd39c43b",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "55283d00-b1a2-521c-99e1-e9d8d88c660d",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-snowman-10.20151220.somatic.indel.vcf.gz.idx",
+          "fileSize": 14606,
+          "fileType": "IDX",
+          "fileMd5sum": "8cae7bbcd28b6a78ad5c53642ae9695c",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "ae5b1daf-05d5-5e41-be2a-9f1d3369d517",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-dRanger-10.20151220.somatic.sv.vcf.gz",
+          "fileSize": 10191,
+          "fileType": "VCF",
+          "fileMd5sum": "f199c6714f7a6880d30bf7aa56e00625",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "c4d10f9f-7e9e-5cb3-a30a-0ff8865952ce",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-dRanger-10.20151220.somatic.sv.vcf.gz.idx",
+          "fileSize": 4212,
+          "fileType": "IDX",
+          "fileMd5sum": "139ce5f29fc0e877d5ae5a5d5e03c3f0",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "8b28796a-1630-5d12-92a7-d8264ee57bc6",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-mutect-v3.20160222.somatic.snv_mnv.vcf.gz",
+          "fileSize": 382815,
+          "fileType": "VCF",
+          "fileMd5sum": "d641e6e373d21d2fc882f2e4550b7b2c",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "a99d2a9c-96c4-5788-9149-79a146f0f925",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "f064f762-c622-11e3-bf01-24c6515278c0.broad-mutect-v3.20160222.somatic.snv_mnv.vcf.gz.idx",
+          "fileSize": 151104,
+          "fileType": "IDX",
+          "fileMd5sum": "797e4ef5c348d4a23e9e83790812d857",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "bd7aa748-d781-523e-99dc-cb7e3469ddc6",
+          "studyId": "LIRI-JP",
+          "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+          "fileName": "0a3c8def-5ef9-4470-b64d-91f62da29abf.xml",
+          "fileSize": 38858,
+          "fileType": "XML",
+          "fileMd5sum": "486853e9fc33dd7f1429c90a6b526b0d",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "info": {},
+        "analysisId": "0a3c8def-5ef9-4470-b64d-91f62da29abf",
+        "variantCallingTool": "Broad variant call pipeline",
+        "matchedNormalSampleSubmitterId": "RK156_B01"
+      },
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      }
+    },
+    {
+      "info": {},
+      "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+      "studyId": "LIRI-JP",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA501653",
+          "specimenId": "SP99145",
+          "submitterSampleId": "RK091_C01",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP99145",
+            "donorId": "DO45211",
+            "submitterSpecimenId": "RK091_C01",
+            "specimenType": "Primary tumour - solid tissue"
+          },
+          "donor": {
+            "donorId": "DO45211",
+            "submitterDonorId": "RK091",
+            "studyId": "LIRI-JP",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "316177db-022d-5121-aba8-ce72a92ee778",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-snowman-11.20160302.somatic.sv.vcf.gz",
+          "fileSize": 404406,
+          "fileType": "VCF",
+          "fileMd5sum": "33b96c263be31852de8d5d15775561c9",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "97c3147f-dd1d-507f-a73d-8646f7ce2a0b",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-snowman-11.20160302.somatic.sv.vcf.gz.idx",
+          "fileSize": 27885,
+          "fileType": "IDX",
+          "fileMd5sum": "3ed262dbc3b1c427177bdd5af5ef5633",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "18917df0-2cc6-5ac5-88d8-f48acf24c92e",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-snowman-11.20160302.germline.sv.vcf.gz",
+          "fileSize": 1853889,
+          "fileType": "VCF",
+          "fileMd5sum": "d3227038bd37e74ff88b07e5408c76ed",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "9abe4aad-9d35-5d4f-955c-8bceb559827e",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-snowman-11.20160302.germline.sv.vcf.gz.idx",
+          "fileSize": 67312,
+          "fileType": "IDX",
+          "fileMd5sum": "a7cf0d572f1649c8791cda7892c7be55",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "5c222a32-a79d-55e0-a490-440217c63393",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-snowman-11.20160302.germline.indel.vcf.gz",
+          "fileSize": 10429379,
+          "fileType": "VCF",
+          "fileMd5sum": "64ef1b8daf5b6eec161555f5cdad3420",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "ad68b7cb-e91c-506e-acae-812ae2ea7678",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-snowman-11.20160302.germline.indel.vcf.gz.idx",
+          "fileSize": 1032907,
+          "fileType": "IDX",
+          "fileMd5sum": "78b2dd0696a1f2ea8ac8e25a77c4e239",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "2af2e398-c27b-5645-b60b-b932a916184d",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-dRanger_snowman-11.20160302.somatic.sv.vcf.gz",
+          "fileSize": 400597,
+          "fileType": "VCF",
+          "fileMd5sum": "7e7f3e23aa8869bfd82ce16382b7bc7d",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "bbb31cb3-f175-52c4-ba66-569e1a1d2ed7",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-dRanger_snowman-11.20160302.somatic.sv.vcf.gz.idx",
+          "fileSize": 27877,
+          "fileType": "IDX",
+          "fileMd5sum": "130e37274d3c7bebcb41d027eea9148d",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "d9388ed4-1603-584f-9b18-5ff53b9bffeb",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-snowman-11.20160302.somatic.indel.vcf.gz",
+          "fileSize": 25270,
+          "fileType": "VCF",
+          "fileMd5sum": "ee313d9cbe077063174d92050dde03e0",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "95e7563e-e8d1-5377-8cfc-1c45a72448da",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-snowman-11.20160302.somatic.indel.vcf.gz.idx",
+          "fileSize": 12044,
+          "fileType": "IDX",
+          "fileMd5sum": "941a7d48a3250de6edcbbde1cbb4b7e1",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "60307755-185e-536e-aa3b-190fb9934844",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-dRanger-11.20160302.somatic.sv.vcf.gz",
+          "fileSize": 2540,
+          "fileType": "VCF",
+          "fileMd5sum": "cbafecb01dea96496176bf7497cb9e80",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "221e532c-a0c8-5573-8399-81f785423e57",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-dRanger-11.20160302.somatic.sv.vcf.gz.idx",
+          "fileSize": 1336,
+          "fileType": "IDX",
+          "fileMd5sum": "de502cd9a25efe6f868f3156e8fd302e",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "2664e052-ba85-5be4-89e0-4f2f06a998c0",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-mutect-v3.20160222.somatic.snv_mnv.vcf.gz",
+          "fileSize": 422502,
+          "fileType": "VCF",
+          "fileMd5sum": "ca10e3bd248498c9427b2b5e324f0242",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "87d9f1f2-3d13-5dd2-8ed5-d175952e2586",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "aabddb20-c622-11e3-bf01-24c6515278c0.broad-mutect-v3.20160222.somatic.snv_mnv.vcf.gz.idx",
+          "fileSize": 160972,
+          "fileType": "IDX",
+          "fileMd5sum": "9029f92d2d1ea6d76b3a88795756aacc",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "8d8a4db8-071d-5385-9266-06e93ca029d0",
+          "studyId": "LIRI-JP",
+          "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+          "fileName": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9.xml",
+          "fileSize": 41214,
+          "fileType": "XML",
+          "fileMd5sum": "080be308183242812e07359f7c9c1566",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "info": {},
+        "analysisId": "cbc64c23-1d6f-40db-a49e-dc54ef222ae9",
+        "variantCallingTool": "Broad variant call pipeline",
+        "matchedNormalSampleSubmitterId": "RK091_B01"
+      },
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      }
+    }
+  ],
+  "totalAnalyses": 3,
+  "currentTotalAnalyses": 3
+}

--- a/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/MALY-DE.analysis.response.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/MALY-DE.analysis.response.json
@@ -1,0 +1,247 @@
+{
+  "analyses":
+  [
+    {
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      },
+      "info": {},
+      "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
+      "studyId": "MALY-DE",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA557689",
+          "specimenId": "SP124981",
+          "submitterSampleId": "tumor_4128852",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP124981",
+            "donorId": "DO221129",
+            "submitterSpecimenId": "tumor_4128852",
+            "specimenType": "Primary tumour - lymph node"
+          },
+          "donor": {
+            "donorId": "DO221129",
+            "submitterDonorId": "4128852",
+            "studyId": "MALY-DE",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "316612a4-4c23-5434-976a-810f8cde06b7",
+          "studyId": "MALY-DE",
+          "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
+          "fileName": "e2fa7251-507e-4d76-95a3-a228adc3885a.MUSE_1-0rc-vcf.20151107.somatic.snv_mnv.vcf.gz",
+          "fileSize": 273787,
+          "fileType": "VCF",
+          "fileMd5sum": "f83b0f9099e8594b589440819ab119cd",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "a9c47630-491b-5587-a58d-6736734d6163",
+          "studyId": "MALY-DE",
+          "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
+          "fileName": "e2fa7251-507e-4d76-95a3-a228adc3885a.MUSE_1-0rc-vcf.20151107.somatic.snv_mnv.vcf.gz.idx",
+          "fileSize": 146924,
+          "fileType": "IDX",
+          "fileMd5sum": "f5629a05fe5b8dd6a63381de259aa935",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "95cbd8c1-1cb1-5c18-8c2d-6f54867d7b72",
+          "studyId": "MALY-DE",
+          "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
+          "fileName": "0a1df2a2-029d-48cc-839c-0a7c89ff972f.xml",
+          "fileSize": 36818,
+          "fileType": "XML",
+          "fileMd5sum": "7240205cac78b6e94a131d2db14de07b",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "info": {},
+        "analysisId": "0a1df2a2-029d-48cc-839c-0a7c89ff972f",
+        "variantCallingTool": "MUSE variant call pipeline",
+        "matchedNormalSampleSubmitterId": "control_4128852"
+      }
+    },
+    {
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      },
+      "info": {},
+      "analysisId": "64e6f498-20ae-4c59-a5f5-36b18f81bd99",
+      "studyId": "MALY-DE",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA542152",
+          "specimenId": "SP116718",
+          "submitterSampleId": "tumor_4113191",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP116718",
+            "donorId": "DO52693",
+            "submitterSpecimenId": "tumor_4113191",
+            "specimenType": "Primary tumour - lymph node"
+          },
+          "donor": {
+            "donorId": "DO52693",
+            "submitterDonorId": "4113191",
+            "studyId": "MALY-DE",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "5d360754-ee81-581f-9b51-dfdd24f7a8d2",
+          "studyId": "MALY-DE",
+          "analysisId": "64e6f498-20ae-4c59-a5f5-36b18f81bd99",
+          "fileName": "64e6f498-20ae-4c59-a5f5-36b18f81bd99.xml",
+          "fileSize": 31669,
+          "fileType": "XML",
+          "fileMd5sum": "8f6ef3b2f3904c523b811e9c5191e159",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "0bafbb56-728e-5e6c-bb87-88e7bb789dab",
+          "studyId": "MALY-DE",
+          "analysisId": "64e6f498-20ae-4c59-a5f5-36b18f81bd99",
+          "fileName": "4e7e6e1f-c648-446f-bdf6-0b1fcc6dfa83.consensus.20160830.somatic.snv_mnv.vcf.gz",
+          "fileSize": 188550,
+          "fileType": "VCF",
+          "fileMd5sum": "02b4602861de0a5529e42d3e66eaa2a6",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "21126ff1-cd5e-5bb2-a55e-3c9f68b2ad14",
+          "studyId": "MALY-DE",
+          "analysisId": "64e6f498-20ae-4c59-a5f5-36b18f81bd99",
+          "fileName": "4e7e6e1f-c648-446f-bdf6-0b1fcc6dfa83.consensus.20160830.somatic.snv_mnv.vcf.gz.tbi",
+          "fileSize": 101608,
+          "fileType": "TBI",
+          "fileMd5sum": "c00c6672cb752c71dd2d1ef23ea559fa",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "info": {},
+        "analysisId": "64e6f498-20ae-4c59-a5f5-36b18f81bd99",
+        "variantCallingTool": " PCAWG SNV-MNV callers",
+        "matchedNormalSampleSubmitterId": "control_4113191"
+      }
+    },
+    {
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      },
+      "info": {},
+      "analysisId": "327c74cd-ee0b-4885-bafd-741e17b8b163",
+      "studyId": "MALY-DE",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA542043",
+          "specimenId": "SP116638",
+          "submitterSampleId": "tumor_4166503",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP116638",
+            "donorId": "DO52662",
+            "submitterSpecimenId": "tumor_4166503",
+            "specimenType": "Primary tumour - lymph node"
+          },
+          "donor": {
+            "donorId": "DO52662",
+            "submitterDonorId": "4166503",
+            "studyId": "MALY-DE",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "46c2fec8-fd4a-5b62-8819-647bf23ac15c",
+          "studyId": "MALY-DE",
+          "analysisId": "327c74cd-ee0b-4885-bafd-741e17b8b163",
+          "fileName": "327c74cd-ee0b-4885-bafd-741e17b8b163.xml",
+          "fileSize": 35287,
+          "fileType": "XML",
+          "fileMd5sum": "91733724f431b0d91b47e37778e6c20e",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "7b32b455-d8e2-5e51-bcad-dad7945c8b15",
+          "studyId": "MALY-DE",
+          "analysisId": "327c74cd-ee0b-4885-bafd-741e17b8b163",
+          "fileName": "866ecfe7-caa6-4565-9418-6b9d6c8a3b43.consensus.20161006.somatic.indel.vcf.gz",
+          "fileSize": 38671,
+          "fileType": "VCF",
+          "fileMd5sum": "020a444fb10ec02b40e141aa9cd0de87",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "4ba753ee-bbb7-5f57-9cda-6e15c519f834",
+          "studyId": "MALY-DE",
+          "analysisId": "327c74cd-ee0b-4885-bafd-741e17b8b163",
+          "fileName": "866ecfe7-caa6-4565-9418-6b9d6c8a3b43.consensus.20161006.somatic.indel.vcf.gz.tbi",
+          "fileSize": 19306,
+          "fileType": "TBI",
+          "fileMd5sum": "7c606af5d37d3788850da1a5f1705feb",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "info": {},
+        "analysisId": "327c74cd-ee0b-4885-bafd-741e17b8b163",
+        "variantCallingTool": "PCAWG InDel callers",
+        "matchedNormalSampleSubmitterId": "control_4166503"
+      }
+    }
+  ],
+  "totalAnalyses": 3,
+  "currentTotalAnalyses": 3
+}

--- a/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/PACA-CA.analysis.response.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/PACA-CA.analysis.response.json
@@ -1,0 +1,463 @@
+{
+  "analyses":
+  [
+    {
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      },
+      "info": {},
+      "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+      "studyId": "PACA-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA533729",
+          "specimenId": "SP125730",
+          "submitterSampleId": "PCSI_0233_Pa_P_526",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP125730",
+            "donorId": "DO51523",
+            "submitterSpecimenId": "PCSI_0233_Pa_P_526",
+            "specimenType": "Primary tumour - other"
+          },
+          "donor": {
+            "donorId": "DO51523",
+            "submitterDonorId": "PCSI_0233",
+            "studyId": "PACA-CA",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "e86158ec-0eb6-50e2-bbb5-7bfed4745db0",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-snvCalling_1-0-132-1.20150722.somatic.snv_mnv.vcf.gz",
+          "fileSize": 543337,
+          "fileType": "VCF",
+          "fileMd5sum": "14ded2a7342f9124421ace5aa920510d",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "bb949d15-334f-5712-9f04-41225a7beb8d",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-snvCalling_1-0-132-1.20150722.somatic.snv_mnv.vcf.gz.tbi",
+          "fileSize": 224729,
+          "fileType": "TBI",
+          "fileMd5sum": "99f0b87f5113494e2fc2284c91dc15e0",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "0474e5f1-3b49-5ec5-8186-a1ffc6952f37",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-indelCalling_1-0-132-1.20150722.somatic.indel.vcf.gz",
+          "fileSize": 5565355,
+          "fileType": "VCF",
+          "fileMd5sum": "0e1e3c924b37d90c99bb04f719a56ce4",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "2910e07c-268b-57a5-877a-0cec35298319",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-indelCalling_1-0-132-1.20150722.somatic.indel.vcf.gz.tbi",
+          "fileSize": 546153,
+          "fileType": "TBI",
+          "fileMd5sum": "1abed463bc92e0d8486699b37af73737",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "54abbcb5-485f-5acd-88e9-50261e0c8e17",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-snvCalling_1-0-132-1.20150722.germline.snv_mnv.vcf.gz",
+          "fileSize": 101384873,
+          "fileType": "VCF",
+          "fileMd5sum": "19b56e546bdcdb7f68dfd603b1b7a8d7",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "425898fd-35d3-5ee2-ac00-50dfd724f4c6",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-snvCalling_1-0-132-1.20150722.germline.snv_mnv.vcf.gz.tbi",
+          "fileSize": 1541330,
+          "fileType": "TBI",
+          "fileMd5sum": "a6113c54193fd7539dffd06f50f04779",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "0d7ee358-01fe-59ce-b62b-0663bec8596d",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-indelCalling_1-0-132-1.20150722.germline.indel.vcf.gz",
+          "fileSize": 72850649,
+          "fileType": "VCF",
+          "fileMd5sum": "c102abc0bfa0b63b2e1ea2ae62e18b80",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "04c24136-c19d-5042-a3cd-36f63c7b4d6b",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-indelCalling_1-0-132-1.20150722.germline.indel.vcf.gz.tbi",
+          "fileSize": 1502241,
+          "fileType": "TBI",
+          "fileMd5sum": "156880f52b94b3119afa3ac6dd7b8ced",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "432779b5-95db-5caf-a529-85a36a707c04",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-copyNumberEstimation_1-0-189-hpc-fix.1508271702.somatic.cnv.vcf.gz",
+          "fileSize": 23763,
+          "fileType": "VCF",
+          "fileMd5sum": "93b219c94687e12b5fda564399fa3319",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "51306186-092d-5e3f-bb3c-028873052eb2",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.dkfz-copyNumberEstimation_1-0-189-hpc-fix.1508271702.somatic.cnv.vcf.gz.tbi",
+          "fileSize": 10691,
+          "fileType": "TBI",
+          "fileMd5sum": "68d76af7c7b9b7c00fa0438101739798",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "4f2bee69-e66e-5af5-856a-a0f3c34b12ff",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.embl-delly_1-0-0-preFilter.20150722.somatic.sv.vcf.gz",
+          "fileSize": 18226,
+          "fileType": "VCF",
+          "fileMd5sum": "6ebd4aa8a821da40955d7fcb879be82a",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "e5d387a1-3b51-5526-ae22-270df2e1fd2f",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.embl-delly_1-0-0-preFilter.20150722.somatic.sv.vcf.gz.tbi",
+          "fileSize": 6134,
+          "fileType": "TBI",
+          "fileMd5sum": "96b05a083d371ae8317651ceffb0f48b",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "3f571505-3bea-5065-956a-4b5a793ad1ed",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.embl-delly_1-0-0-preFilter.20150722.germline.sv.vcf.gz",
+          "fileSize": 161511,
+          "fileType": "VCF",
+          "fileMd5sum": "f3a99bd737b3b416aa34e131b939b2a0",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "e8569e7c-6ae4-5aeb-ae50-b94366aae5df",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "bcef0b6c-6584-4090-9d28-ef784a7e5fbb.embl-delly_1-0-0-preFilter.20150722.germline.sv.vcf.gz.tbi",
+          "fileSize": 19769,
+          "fileType": "TBI",
+          "fileMd5sum": "cb856f2d5837c5f065c7c598dcd795b5",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "bbbbc35b-9ea3-5191-b6c8-9092975d8033",
+          "studyId": "PACA-CA",
+          "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+          "fileName": "744c62bf-4747-4ab2-aca9-50879cea82e0.xml",
+          "fileSize": 60087,
+          "fileType": "XML",
+          "fileMd5sum": "64db344f980be12737566635acf5820f",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "info": {},
+        "analysisId": "744c62bf-4747-4ab2-aca9-50879cea82e0",
+        "variantCallingTool": "DKFZ/EMBL variant call pipeline",
+        "matchedNormalSampleSubmitterId": "PCSI_0233_Ly_R"
+      }
+    },
+    {
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      },
+      "info": {},
+      "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+      "studyId": "PACA-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA533758",
+          "specimenId": "SP125791",
+          "submitterSampleId": "ASHPC_0022_Pa_P",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP125791",
+            "donorId": "DO51498",
+            "submitterSpecimenId": "ASHPC_0022_Pa_P",
+            "specimenType": "Primary tumour - other"
+          },
+          "donor": {
+            "donorId": "DO51498",
+            "submitterDonorId": "PCSI_0450",
+            "studyId": "PACA-CA",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "e122b153-c98b-530d-879a-11871a427d1b",
+          "studyId": "PACA-CA",
+          "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+          "fileName": "94652d14-2e4d-4f4a-a4f7-8df77df788c0.svcp_1-0-8.20150911.somatic.indel.vcf.gz",
+          "fileSize": 58091383,
+          "fileType": "VCF",
+          "fileMd5sum": "4824d68baf7c2b06f5a652bb5462b9b4",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "b26a535c-3531-55ad-8725-17aa6afb22c2",
+          "studyId": "PACA-CA",
+          "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+          "fileName": "94652d14-2e4d-4f4a-a4f7-8df77df788c0.svcp_1-0-8.20150911.somatic.indel.vcf.gz.tbi",
+          "fileSize": 1524609,
+          "fileType": "TBI",
+          "fileMd5sum": "894fa70742c16ed7f845abd68609f20c",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "36ede5a5-fcde-5b6a-95c1-af28321fbd39",
+          "studyId": "PACA-CA",
+          "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+          "fileName": "94652d14-2e4d-4f4a-a4f7-8df77df788c0.svfix2_4-0-12.20160208.somatic.sv.vcf.gz",
+          "fileSize": 59407,
+          "fileType": "VCF",
+          "fileMd5sum": "0502184e75c3a3fb83e2aa6ab536e78a",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "b9800f14-13d5-55cf-9383-a65b5446116a",
+          "studyId": "PACA-CA",
+          "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+          "fileName": "94652d14-2e4d-4f4a-a4f7-8df77df788c0.svfix2_4-0-12.20160208.somatic.sv.vcf.gz.tbi",
+          "fileSize": 2961,
+          "fileType": "TBI",
+          "fileMd5sum": "1ba234eb0c457dba2942215d3fc4741a",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "5c1fcacb-7c66-53a6-8fb6-93d1281e55b8",
+          "studyId": "PACA-CA",
+          "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+          "fileName": "94652d14-2e4d-4f4a-a4f7-8df77df788c0.svcp_1-0-8.20150911.somatic.cnv.vcf.gz",
+          "fileSize": 2964,
+          "fileType": "VCF",
+          "fileMd5sum": "bafebb1c613c348c696dc8f940ce1039",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "52db8e51-5b3e-56ce-b939-0a96b4dfbce3",
+          "studyId": "PACA-CA",
+          "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+          "fileName": "94652d14-2e4d-4f4a-a4f7-8df77df788c0.svcp_1-0-8.20150911.somatic.cnv.vcf.gz.tbi",
+          "fileSize": 4783,
+          "fileType": "TBI",
+          "fileMd5sum": "725becdd11e63c371e57a987420846bd",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "e704d3f5-1274-5cdd-924f-609159e121cc",
+          "studyId": "PACA-CA",
+          "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+          "fileName": "94652d14-2e4d-4f4a-a4f7-8df77df788c0.svcp_1-0-8.20150911.somatic.snv_mnv.vcf.gz",
+          "fileSize": 1704966,
+          "fileType": "VCF",
+          "fileMd5sum": "37ee70b282788eb0660f7d965f355898",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "6b32cfec-e82c-5528-b908-8e00ae927578",
+          "studyId": "PACA-CA",
+          "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+          "fileName": "94652d14-2e4d-4f4a-a4f7-8df77df788c0.svcp_1-0-8.20150911.somatic.snv_mnv.vcf.gz.tbi",
+          "fileSize": 303747,
+          "fileType": "TBI",
+          "fileMd5sum": "91dece67c383a67123caae382a130cb9",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "47fc8458-df52-5ad1-a0fc-cd2c277ecb93",
+          "studyId": "PACA-CA",
+          "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+          "fileName": "916b5a92-cea6-11e5-af30-d4714d100685.xml",
+          "fileSize": 60346,
+          "fileType": "XML",
+          "fileMd5sum": "a2a10568288e3756745dddaee91df5d5",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "info": {},
+        "analysisId": "916b5a92-cea6-11e5-af30-d4714d100685",
+        "variantCallingTool": "Sanger variant call pipeline",
+        "matchedNormalSampleSubmitterId": "ASHPC_0022_Pa_R"
+      }
+    },
+    {
+      "analysisType": {
+        "name": "variantCall",
+        "version": 1
+      },
+      "info": {},
+      "analysisId": "b8e09611-225a-4de6-87dc-104753072252",
+      "studyId": "PACA-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA520221",
+          "specimenId": "SP125732",
+          "submitterSampleId": "PCSI_0083_Pa_P_526",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP125732",
+            "donorId": "DO35442",
+            "submitterSpecimenId": "PCSI_0083_Pa_P_526",
+            "specimenType": "Primary tumour - other"
+          },
+          "donor": {
+            "donorId": "DO35442",
+            "submitterDonorId": "PCSI_0083",
+            "studyId": "PACA-CA",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "ca8479dc-8f00-5757-b433-c3cf5b76f255",
+          "studyId": "PACA-CA",
+          "analysisId": "b8e09611-225a-4de6-87dc-104753072252",
+          "fileName": "b8e09611-225a-4de6-87dc-104753072252.xml",
+          "fileSize": 33270,
+          "fileType": "XML",
+          "fileMd5sum": "bc3d7e8d1acc6a2d20608e10d6a6ed05",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "9727c61d-3871-54f1-a65a-2d1d91acd242",
+          "studyId": "PACA-CA",
+          "analysisId": "b8e09611-225a-4de6-87dc-104753072252",
+          "fileName": "536dedba-46c4-4a21-b112-13c030b13069.consensus.20161006.somatic.indel.vcf.gz",
+          "fileSize": 329863,
+          "fileType": "VCF",
+          "fileMd5sum": "01e54034c70b85812e9aac58f2525594",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "08519ab5-8665-58dc-8476-1c40cae5b789",
+          "studyId": "PACA-CA",
+          "analysisId": "b8e09611-225a-4de6-87dc-104753072252",
+          "fileName": "536dedba-46c4-4a21-b112-13c030b13069.consensus.20161006.somatic.indel.vcf.gz.tbi",
+          "fileSize": 148925,
+          "fileType": "TBI",
+          "fileMd5sum": "5b83369174136b88f16a08ab87bb67f7",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "info": {},
+        "analysisId": "b8e09611-225a-4de6-87dc-104753072252",
+        "variantCallingTool": "PCAWG InDel callers",
+        "matchedNormalSampleSubmitterId": "PCSI_0083_Du_R"
+      }
+    }
+  ],
+  "totalAnalyses": 3,
+  "currentTotalAnalyses": 3
+}

--- a/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/PEME-CA.aws.conflicting.study.response.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/PEME-CA.aws.conflicting.study.response.json
@@ -1,0 +1,90 @@
+{
+  "analyses":
+  [
+    {
+      "analysisType": {
+        "name": "sequencingRead",
+        "version": 1
+      },
+      "info": {
+        "dcc_project_code": "PEME-CA",
+        "isPcawg": false
+      },
+      "analysisId": "EGAZ00001254245",
+      "studyId": "PEME-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA604905",
+          "specimenId": "SP200947",
+          "submitterSampleId": "MDT-AP-0432_control",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP200947",
+            "donorId": "DO232959",
+            "submitterSpecimenId": "MDT-AP-0432_control_specimen",
+            "specimenType": "Normal - blood derived"
+          },
+          "donor": {
+            "donorId": "DO232959",
+            "submitterDonorId": "MDT-AP-0432",
+            "studyId": "PEME-CA",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "464116e4-afc9-5879-b567-6f54513a32dc",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "bundle.EGAZ00001254247.xml",
+          "fileSize": 6352,
+          "fileType": "XML",
+          "fileMd5sum": "cad2b396e0f7dc5384a5275f89ccad3a",
+          "fileAccess": "open",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "6aa8d318-e168-520e-9d1e-cef127ee6b65",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "b2e40ebb719e1754e99be2e752239639.control_MDT-AP-0432_merged.mdup.bam.bai",
+          "fileSize": 8982928,
+          "fileType": "BAI",
+          "fileMd5sum": "227a2a11d660a8a53a7375c6623034e2",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "9ce9358d-c93a-5f83-8032-4addcb84b51a",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "b2e40ebb719e1754e99be2e752239639.control_MDT-AP-0432_merged.mdup.bam",
+          "fileSize": 77675501639,
+          "fileType": "BAM",
+          "fileMd5sum": "b2e40ebb719e1754e99be2e752239639",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "analysisId": "EGAZ00001254247",
+        "aligned": true,
+        "libraryStrategy": "WGS",
+        "info": {}
+      }
+    }
+  ],
+  "totalAnalyses": 1,
+  "currentTotalAnalyses": 1
+}

--- a/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/PEME-CA.aws.study.response.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/PEME-CA.aws.study.response.json
@@ -1,0 +1,90 @@
+{
+  "analyses":
+  [
+    {
+      "analysisType": {
+        "name": "sequencingRead",
+        "version": 1
+      },
+      "info": {
+        "dcc_project_code": "PEME-CA",
+        "isPcawg": false
+      },
+      "analysisId": "EGAZ00001254247",
+      "studyId": "PEME-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA604905",
+          "specimenId": "SP200947",
+          "submitterSampleId": "MDT-AP-0432_control",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP200947",
+            "donorId": "DO232959",
+            "submitterSpecimenId": "MDT-AP-0432_control_specimen",
+            "specimenType": "Normal - blood derived"
+          },
+          "donor": {
+            "donorId": "DO232959",
+            "submitterDonorId": "MDT-AP-0432",
+            "studyId": "PEME-CA",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "464116e4-afc9-5879-b567-6f54513a32dc",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "bundle.EGAZ00001254247.xml",
+          "fileSize": 6352,
+          "fileType": "XML",
+          "fileMd5sum": "cad2b396e0f7dc5384a5275f89ccad3a",
+          "fileAccess": "open",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "6aa8d318-e168-520e-9d1e-cef127ee6b65",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "b2e40ebb719e1754e99be2e752239639.control_MDT-AP-0432_merged.mdup.bam.bai",
+          "fileSize": 8982928,
+          "fileType": "BAI",
+          "fileMd5sum": "227a2a11d660a8a53a7375c6623034e2",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "9ce9358d-c93a-5f83-8032-4addcb84b51a",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "b2e40ebb719e1754e99be2e752239639.control_MDT-AP-0432_merged.mdup.bam",
+          "fileSize": 77675501639,
+          "fileType": "BAM",
+          "fileMd5sum": "b2e40ebb719e1754e99be2e752239639",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "analysisId": "EGAZ00001254247",
+        "aligned": true,
+        "libraryStrategy": "WGS",
+        "info": {}
+      }
+    }
+  ],
+  "totalAnalyses": 1,
+  "currentTotalAnalyses": 1
+}

--- a/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/PEME-CA.study.response.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/PEME-CA.study.response.json
@@ -1,0 +1,198 @@
+{
+  "analyses":
+  [
+    {
+      "analysisType": {
+        "name": "sequencingRead",
+        "version": 1
+      },
+      "info": {
+        "dcc_project_code": "PEME-CA",
+        "isPcawg": false
+      },
+      "analysisId": "EGAZ00001254368",
+      "studyId": "PEME-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "sampleId": "SA604924",
+          "specimenId": "SP201301",
+          "submitterSampleId": "MDT-AP-0749_tumor",
+          "sampleType": "DNA",
+          "specimen": {
+            "specimenId": "SP201301",
+            "donorId": "DO232978",
+            "submitterSpecimenId": "MDT-AP-0749_tumor_specimen",
+            "specimenType": "Primary tumour - solid tissue",
+            "info": {
+              "dcc_project_code": "PEME-CA",
+              "isPcawg": false
+            }
+          },
+          "donor": {
+            "donorId": "DO232978",
+            "submitterDonorId": "MDT-AP-0749",
+            "studyId": "PEME-CA",
+            "gender": "Female",
+            "info": {
+              "dcc_project_code": "PEME-CA",
+              "isPcawg": false
+            }
+          },
+          "info": {
+            "dcc_project_code": "PEME-CA",
+            "isPcawg": false
+          }
+        }
+      ],
+      "files": [
+        {
+          "objectId": "41ba4fb3-9428-50b5-af6c-d779cd59b04d",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254368",
+          "fileName": "bundle.EGAZ00001254368.xml",
+          "fileSize": 6342,
+          "fileType": "XML",
+          "fileMd5sum": "fb157ece007dc31b3d34add273efedcb",
+          "fileAccess": "open",
+          "dataType": "AlignedReads",
+          "info": {
+            "dcc_project_code": "PEME-CA",
+            "isPcawg": false
+          }
+        },
+        {
+          "objectId": "d819f154-2292-56f7-94f3-bbe03fb45bc5",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254368",
+          "fileName": "29ff9df727803d20834b9997bc17e970.tumor_MDT-AP-0749_merged.mdup.bam.bai",
+          "fileSize": 8939816,
+          "fileType": "BAI",
+          "fileMd5sum": "e2a83668aa4cfe4f4048e75212d44f19",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads",
+          "info": {
+            "dcc_project_code": "PEME-CA",
+            "isPcawg": false,
+            "nested": {
+              "nestedAgain": [
+                {
+                  "theeNested": "word"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "objectId": "43d29864-6756-51f0-bb2a-ba7cff860778",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254368",
+          "fileName": "29ff9df727803d20834b9997bc17e970.tumor_MDT-AP-0749_merged.mdup.bam",
+          "fileSize": 88906416144,
+          "fileType": "BAM",
+          "fileMd5sum": "29ff9df727803d20834b9997bc17e970",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads",
+          "info": {
+            "dcc_project_code": "PEME-CA",
+            "isPcawg": false
+          }
+        }
+      ],
+      "experiment": {
+        "analysisId": "EGAZ00001254368",
+        "aligned": true,
+        "libraryStrategy": "WGS",
+        "info": {}
+      }
+    },
+    {
+      "analysisType": {
+        "name": "sequencingRead",
+        "version": 1
+      },
+      "info": {
+        "dcc_project_code": "PEME-CA",
+        "isPcawg": false
+      },
+      "analysisId": "EGAZ00001254247",
+      "studyId": "PEME-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA604905",
+          "specimenId": "SP200947",
+          "submitterSampleId": "MDT-AP-0432_control",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP200947",
+            "donorId": "DO232959",
+            "submitterSpecimenId": "MDT-AP-0432_control_specimen",
+            "specimenType": "Normal - blood derived"
+          },
+          "donor": {
+            "donorId": "DO232959",
+            "submitterDonorId": "MDT-AP-0432",
+            "studyId": "PEME-CA",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "464116e4-afc9-5879-b567-6f54513a32dc",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "bundle.EGAZ00001254247.xml",
+          "fileSize": 6352,
+          "fileType": "XML",
+          "fileMd5sum": "cad2b396e0f7dc5384a5275f89ccad3a",
+          "fileAccess": "open",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "6aa8d318-e168-520e-9d1e-cef127ee6b65",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "b2e40ebb719e1754e99be2e752239639.control_MDT-AP-0432_merged.mdup.bam.bai",
+          "fileSize": 8982928,
+          "fileType": "BAI",
+          "fileMd5sum": "227a2a11d660a8a53a7375c6623034e2",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "9ce9358d-c93a-5f83-8032-4addcb84b51a",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "b2e40ebb719e1754e99be2e752239639.control_MDT-AP-0432_merged.mdup.bam",
+          "fileSize": 77675501639,
+          "fileType": "BAM",
+          "fileMd5sum": "b2e40ebb719e1754e99be2e752239639",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "analysisId": "EGAZ00001254247",
+        "aligned": true,
+        "libraryStrategy": "WGS",
+        "info": {}
+      }
+    }
+  ],
+  "totalAnalyses": 2,
+  "currentTotalAnalyses": 2
+}

--- a/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/empty-response.json
+++ b/maestro-app/src/test/resources/fixtures/FileCentricIntegrationTest/empty-response.json
@@ -1,0 +1,7 @@
+{
+  "analyses":
+  [
+  ],
+  "totalAnalyses": 2,
+  "currentTotalAnalyses": 0
+}

--- a/maestro-app/src/test/resources/fixtures/SongStudyDAOTest/PEME-CA.response.json
+++ b/maestro-app/src/test/resources/fixtures/SongStudyDAOTest/PEME-CA.response.json
@@ -1,0 +1,174 @@
+{
+  "analyses":
+  [
+    {
+      "analysisType": {
+        "name": "sequencingRead",
+        "version": 1
+      },
+      "info": {
+        "dcc_project_code": "PEME-CA",
+        "isPcawg": false
+      },
+      "analysisId": "EGAZ00001254368",
+      "studyId": "PEME-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA604924",
+          "specimenId": "SP201301",
+          "submitterSampleId": "MDT-AP-0749_tumor",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP201301",
+            "donorId": "DO232978",
+            "submitterSpecimenId": "MDT-AP-0749_tumor_specimen",
+            "specimenType": "Primary tumour - solid tissue"
+          },
+          "donor": {
+            "donorId": "DO232978",
+            "submitterDonorId": "MDT-AP-0749",
+            "studyId": "PEME-CA",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "41ba4fb3-9428-50b5-af6c-d779cd59b04d",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254368",
+          "fileName": "bundle.EGAZ00001254368.xml",
+          "fileSize": 6342,
+          "fileType": "XML",
+          "fileMd5sum": "fb157ece007dc31b3d34add273efedcb",
+          "fileAccess": "open",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "d819f154-2292-56f7-94f3-bbe03fb45bc5",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254368",
+          "fileName": "29ff9df727803d20834b9997bc17e970.tumor_MDT-AP-0749_merged.mdup.bam.bai",
+          "fileSize": 8939816,
+          "fileType": "BAI",
+          "fileMd5sum": "e2a83668aa4cfe4f4048e75212d44f19",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "43d29864-6756-51f0-bb2a-ba7cff860778",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254368",
+          "fileName": "29ff9df727803d20834b9997bc17e970.tumor_MDT-AP-0749_merged.mdup.bam",
+          "fileSize": 88906416144,
+          "fileType": "BAM",
+          "fileMd5sum": "29ff9df727803d20834b9997bc17e970",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "analysisId": "EGAZ00001254368",
+        "aligned": true,
+        "libraryStrategy": "WGS",
+        "info": {}
+      }
+    },
+    {
+      "analysisType": {
+        "name": "sequencingRead",
+        "version": 1
+      },
+      "info": {
+        "dcc_project_code": "PEME-CA",
+        "isPcawg": false
+      },
+      "analysisId": "EGAZ00001254247",
+      "studyId": "PEME-CA",
+      "analysisState": "PUBLISHED",
+      "updatedAt": "2020-12-02T17:18:32.353334",
+      "firstPublishedAt": "2020-12-02T17:18:32.353334",
+      "publishedAt": "2020-12-02T17:18:32.353334",
+      "samples": [
+        {
+          "info": {},
+          "sampleId": "SA604905",
+          "specimenId": "SP200947",
+          "submitterSampleId": "MDT-AP-0432_control",
+          "sampleType": "DNA",
+          "specimen": {
+            "info": {},
+            "specimenId": "SP200947",
+            "donorId": "DO232959",
+            "submitterSpecimenId": "MDT-AP-0432_control_specimen",
+            "specimenType": "Normal - blood derived"
+          },
+          "donor": {
+            "donorId": "DO232959",
+            "submitterDonorId": "MDT-AP-0432",
+            "studyId": "PEME-CA",
+            "gender": "Female",
+            "info": {}
+          }
+        }
+      ],
+      "files": [
+        {
+          "info": {},
+          "objectId": "464116e4-afc9-5879-b567-6f54513a32dc",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "bundle.EGAZ00001254247.xml",
+          "fileSize": 6352,
+          "fileType": "XML",
+          "fileMd5sum": "cad2b396e0f7dc5384a5275f89ccad3a",
+          "fileAccess": "open",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "6aa8d318-e168-520e-9d1e-cef127ee6b65",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "b2e40ebb719e1754e99be2e752239639.control_MDT-AP-0432_merged.mdup.bam.bai",
+          "fileSize": 8982928,
+          "fileType": "BAI",
+          "fileMd5sum": "227a2a11d660a8a53a7375c6623034e2",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        },
+        {
+          "info": {},
+          "objectId": "9ce9358d-c93a-5f83-8032-4addcb84b51a",
+          "studyId": "PEME-CA",
+          "analysisId": "EGAZ00001254247",
+          "fileName": "b2e40ebb719e1754e99be2e752239639.control_MDT-AP-0432_merged.mdup.bam",
+          "fileSize": 77675501639,
+          "fileType": "BAM",
+          "fileMd5sum": "b2e40ebb719e1754e99be2e752239639",
+          "fileAccess": "controlled",
+          "dataType": "AlignedReads"
+        }
+      ],
+      "experiment": {
+        "analysisId": "EGAZ00001254247",
+        "aligned": true,
+        "libraryStrategy": "WGS",
+        "info": {}
+      }
+    }
+  ],
+  "totalAnalyses": 2,
+  "currentTotalAnalyses": 2
+}
+

--- a/maestro-app/src/test/resources/fixtures/SongStudyDAOTest/empty-response.json
+++ b/maestro-app/src/test/resources/fixtures/SongStudyDAOTest/empty-response.json
@@ -1,0 +1,8 @@
+{
+  "analyses":
+  [
+  ],
+  "totalAnalyses": 2,
+  "currentTotalAnalyses": 0
+}
+

--- a/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/metadata/study/GetAnalysisResponse.java
+++ b/maestro-domain/src/main/java/bio/overture/maestro/domain/entities/metadata/study/GetAnalysisResponse.java
@@ -1,0 +1,16 @@
+package bio.overture.maestro.domain.entities.metadata.study;
+
+import java.util.List;
+import lombok.*;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GetAnalysisResponse {
+  private List<Analysis> analyses;
+  private Integer totalAnalyses;
+  private Integer currentTotalAnalyses;
+}


### PR DESCRIPTION
Maestro now talks to the new performance upgraded get analysis song endpoint for both analysis and file centric indices.
- Adds env variable `pageLimit` to allow customized streaming control. 
- default page limit is set to 100.
- Updates integration tests.