### PR TITLE
Add DELETE endpoint to remove a record from the index

### DIFF
--- a/apps/server/src/api-docs/indexing.yml
+++ b/apps/server/src/api-docs/indexing.yml
@@ -108,3 +108,44 @@
         $ref: '#/components/responses/ServerError'
       503:
         $ref: '#/components/responses/ServiceUnavailableError'
+  delete:
+    summary: Removes the index entry for a specific record identified by its ID within an organization in the given repository.
+    description: This operation allows fine-grained removal at the record level. The `repositoryCode` identifies the repository, `organization` specifies the organization, and `id` refers to the unique identifier of the record to be removed from the index.
+    tags:
+      - Indexing
+    parameters:
+      - name: repositoryCode
+        in: path
+        required: true
+        schema:
+          type: string
+        description: A unique code that identifies the repository where data will be removed from the index
+      - name: organization
+        in: path
+        required: true
+        schema:
+          type: string
+        description: The name of the organization within the repository for which data will be removed from the index
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: The unique identifier of the record to be removed from the index within the specified organization.
+    responses:
+      202:
+        description: Accepted response indicating that the removal operation has been queued for processing
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AcceptedResponse'
+      400:
+        $ref: '#/components/responses/BadRequest'
+      401:
+        $ref: '#/components/responses/UnauthorizedError'
+      404:
+        $ref: '#/components/responses/NotFound'
+      500:
+        $ref: '#/components/responses/ServerError'
+      503:
+        $ref: '#/components/responses/ServiceUnavailableError'

--- a/apps/server/src/controllers/indexerController.ts
+++ b/apps/server/src/controllers/indexerController.ts
@@ -65,8 +65,28 @@ const indexRecord = validateRequest(indexRecordRequestschema, async (req, res, n
 	}
 });
 
+const removeIndexRecord = validateRequest(indexRecordRequestschema, async (req, res, next) => {
+	try {
+		const repoCode = req.params.repositoryCode;
+		const organization = req.params.organization;
+		const id = req.params.id;
+
+		const result = await maestroProvider.api?.removeIndexRecord(repoCode, organization, id);
+		if (result?.successful) {
+			// Accepted
+			res.status(202).send(result);
+		} else {
+			// Bad Request
+			res.status(400).send(result);
+		}
+	} catch (error) {
+		next(error);
+	}
+});
+
 export default {
 	indexRepository,
 	indexOrganization,
 	indexRecord,
+	removeIndexRecord,
 };

--- a/apps/server/src/routes/indexer.ts
+++ b/apps/server/src/routes/indexer.ts
@@ -8,6 +8,7 @@ export const indexerRouter: Router = (() => {
 	router.post('/repository/:repositoryCode', indexerController.indexRepository);
 	router.post('/repository/:repositoryCode/organization/:organization', indexerController.indexOrganization);
 	router.post('/repository/:repositoryCode/organization/:organization/id/:id', indexerController.indexRecord);
+	router.delete('/repository/:repositoryCode/organization/:organization/id/:id', indexerController.removeIndexRecord);
 
 	return router;
 })();

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,17 @@ curl -X POST \
 	-H 'cache-control: no-cache'
 ```
 
+- Remove a record from the index by Analysis:
+
+`DELETE http://maestro.host:11235/index/repository/<repo>/organization/<organization or studyId>/id/<analysisId>`
+
+```bash
+	curl -X DELETE \
+	http://localhost:11235/index/repository/collab/organization/BASH-AR/id/ad7cabf8-df45-40fe6 \
+	-H 'Content-Type: application/json' \
+	-H 'cache-control: no-cache'
+```
+
 - Index an entire repository:
 
 `POST http://maestro.host:11235/index/repository/<repo-code>`


### PR DESCRIPTION
# Description
Adds a REST DELETE endpoint for removing a single ElasticSearch document from the index.

## Details
- Added new Route `DELETE /index/repository/:repositoryCode/organization/:organization/id/:id`
- Controller is using the `removeIndexRecord` provider function that already existed but wasn't exposed at the HTTP layer
- Updated openapi docs to describe the above route
- Updated `usage.md` with an example of usage.

## Issue related
- https://github.com/overture-stack/maestro/issues/296